### PR TITLE
module-pod-jp を translationにリネーム

### DIFF
--- a/lib/PJP/M/Index/Article.pm
+++ b/lib/PJP/M/Index/Article.pm
@@ -60,7 +60,7 @@ sub generate {
     my @files;
     for my $base (map { File::Spec->catdir( $c->assets_dir(), $_) } qw(
         perldoc.jp/docs/articles/
-        module-pod-jp/docs/articles/
+        translation/docs/articles/
     )) {
         push @files, $class->_get_files($c, $base) if -d $base;
     }

--- a/lib/PJP/M/Index/Module.pm
+++ b/lib/PJP/M/Index/Module.pm
@@ -61,7 +61,7 @@ sub generate {
         Moose-Doc-JA/
         MooseX-Getopt-Doc-JA/
         perldoc.jp/docs/modules/
-        module-pod-jp/docs/modules/
+        translation/docs/modules/
     )) {
         push @mods, $class->_generate($c, $base);
     }

--- a/lib/PJP/M/Repository.pm
+++ b/lib/PJP/M/Repository.pm
@@ -46,7 +46,7 @@ sub recent_data {
       }
   }em;
 
-  foreach my $repos (qw/Moose-Doc-JA MooseX-Getopt-Doc-JA module-pod-jp/) {
+  foreach my $repos (qw/Moose-Doc-JA MooseX-Getopt-Doc-JA translation/) {
       foreach my $file (File::Find::Rule->file()->name(qr/\.(pod|html|md)$/)->in("$assets_dir$repos")) {
           my $git = qx{cd $assets_dir/$repos/; git log -1 --date=iso --pretty='%cd -- %an' --since='$date' $file} or next;
           my ($date, $time, $author) = $git =~m{^(\d{4}-\d{2}-\d{2})( \d{2}:\d{2}:\d{2}) \+\d{4} -- (.+)$} or die $git;

--- a/script/update.pl
+++ b/script/update.pl
@@ -50,12 +50,12 @@ _SHELL_
     }
 }
 
-if (! -d $assets_dir . '/module-pod-jp/') {
-    system(qq{git clone https://github.com/perldoc-jp/module-pod-jp.git $assets_dir/module-pod-jp/});
+if (! -d $assets_dir . '/translation/') {
+    system(qq{git clone https://github.com/perldoc-jp/translation.git $assets_dir/translation/});
 }
 
 if (! $ENV{SKIP_ASSETS_UPDATE}) {
-    system(qq{cd $assets_dir/module-pod-jp; git pull origin master});
+    system(qq{cd $assets_dir/translation; git pull origin master});
 }
 
 foreach my $jpa_module (qw/MooseX-Getopt-Doc-JA  Moose-Doc-JA/) {

--- a/tmpl/about.tt
+++ b/tmpl/about.tt
@@ -23,12 +23,12 @@ miyagawaさんが最初に始めたものを tokuhiromさんが引き継ぎ、�
 </p>
 <h2>git リポジトリ(github)</h2>
 <ul>
-<li><a href="https://github.com/perldoc-jp/module-pod-jp">github のリポジトリ</a></li>
+<li><a href="https://github.com/perldoc-jp/translation">github のリポジトリ</a></li>
 </ul>
 <p>
     git がいいという場合はにこちらにおいてください。<br />
     このリポジトリは、JPRP とは関係がありません。こちらの方がよりゆるい管理態勢になっています。<br /><br />
-    こちらに貢献する場合は、fork して pull-reqeust を送るか、何度もコミットしたい場合は、<a href="https://github.com/perldoc-jp/module-pod-jp/issues/new">issues</a> にコミット権が欲しい旨を書き込んで下さい。
+    こちらに貢献する場合は、fork して pull-reqeust を送るか、何度もコミットしたい場合は、<a href="https://github.com/perldoc-jp/translation/issues/new">issues</a> にコミット権が欲しい旨を書き込んで下さい。
 </p>
 
 <h2>IRC</h2>
@@ -44,7 +44,7 @@ miyagawaさんが最初に始めたものを tokuhiromさんが引き継ぎ、�
 </p>
 <ul>
 <li><a href="https://osdn.net/projects/perldocjp/ticket/">JPRPの誤訳の報告</a></li>
-<li><a href="https://github.com/perldoc-jp/module-pod-jp/issues">gitリポジトリの誤訳の報告</a></li>
+<li><a href="https://github.com/perldoc-jp/translation/issues">gitリポジトリの誤訳の報告</a></li>
 <li><a href="https://github.com/perldoc-jp/perldoc.jp/issues">サイトの不具合の報告</a></li>
 </ul>
 <h2>謝辞</h2>

--- a/tmpl/index/article.tt
+++ b/tmpl/index/article.tt
@@ -11,7 +11,7 @@
                 <tr>
                     <td nowrap="nowrap">
                         <a href="/docs/articles/[% v.distvname %]">[% v.name %]</a>
-                        [% IF v.repository=='module-pod-jp' %]
+                        [% IF v.repository=='translation' %]
                             <img src="/static/img/github.png" width="16" height="16" />
                         [% END %]
                     </td>

--- a/tmpl/index/module.tt
+++ b/tmpl/index/module.tt
@@ -19,7 +19,7 @@
                                 <span class="old">(Latest: [% v.latest_version %])</span>
                             [% END %]
                         [% END %]
-                        [% IF v.repository=='module-pod-jp' %]
+                        [% IF v.repository=='translation' %]
                             <img src="/static/img/github.png" width="16" height="16" />
                         [% END %]
                         [% IF v.versions.size() > 1 %]

--- a/tmpl/manners.tt
+++ b/tmpl/manners.tt
@@ -401,7 +401,7 @@ JPRP、gitリポジトリで翻訳された場合は、当サイトのRSSフィ�
 Perlの用語の対訳表を以下にまとめています。
 </p>
 <ul>
-<li><a href="https://github.com/perldoc-jp/module-pod-jp/blob/master/translation_table.md">対訳表</a></li>
+<li><a href="https://github.com/perldoc-jp/translation/blob/master/translation_table.md">対訳表</a></li>
 </ul>
 
 <h2 id="see_also">JPRPの参考文書</h2>

--- a/tmpl/pod.tt
+++ b/tmpl/pod.tt
@@ -34,16 +34,16 @@
               </div><form action="/docs/[% path %]/diff">
               <select name="target">[% FOR v IN others %]<option value="[% v.path %]">[% v.distvname  | replace('^[\w:-]+?-(?=\d+)') %]</option>[% END %]</select>
               <input type="submit" value="diff" />
-              </form> 
+              </form>
             [% END %]
         [% END %]
             [% IF ! c().req.path.match('^/func') && ! c().req.path.match('^/variable') %]
               <div class="Source"><a href="[% c().req.uri() %].pod">Source</a></div>
             [% END %]
-            [% IF repository=="module-pod-jp" %]
-            <div class="Edit"><a target="_blank" href="https://github.com/perldoc-jp/module-pod-jp/blob/master/docs/[% path %]">編集(github)</a></div>
-            <div><a target="_blank" href="https://github.com/perldoc-jp/module-pod-jp/commits/master/docs/[% path %]">変更履歴(github)</a></div>
-            <div><a target="_blank" href="https://github.com/perldoc-jp/module-pod-jp/issues/new?title=[% distvname | url %][% "の誤訳の報告" | url %]">誤訳の報告</a></div>
+            [% IF repository=="translation" %]
+            <div class="Edit"><a target="_blank" href="https://github.com/perldoc-jp/translation/blob/master/docs/[% path %]">編集(github)</a></div>
+            <div><a target="_blank" href="https://github.com/perldoc-jp/translation/commits/master/docs/[% path %]">変更履歴(github)</a></div>
+            <div><a target="_blank" href="https://github.com/perldoc-jp/translation/issues/new?title=[% distvname | url %][% "の誤訳の報告" | url %]">誤訳の報告</a></div>
             [% ELSIF repository=="Moose-Doc-JA" || repository=="MooseX-Getopt-Doc-JA" %]
             [% github_path = path.replace('^modules/', '')%]
             <div><a target="_blank" href="https://github.com/jpa/Moose-Doc-JA/commits/master/[% github_path %]">変更履歴(github)</a></div>


### PR DESCRIPTION
## 変更の背景

OSDN.net のJPRPを移管の一環で、受け皿になるmodule-pod-jpをtranslationにリネームする
https://github.com/perldoc-jp/wg-perl-document/issues/25

## やったこと

- module-pod-jp となっていた箇所を、translationに書き換えました。
   - 本変更後、module-pod-jp は見つからないです。

```
❯ rg 'module-pod-jp' |wc -l
       0
```

## 補足：反映作業手順

- [x] perldoc-jp/module-pod-jp を、perldoc-jp/translationにリネーム
- [x] 本PRのマージ
- [ ] perldoc.jp が動作してる環境で、module-pod-jp を translationにリネーム
  - cd /var/lib/jpa/perldoc.jp/assets
  - mv module-pod-jp translation
  - git remote oriign set-url origin https://github.com/perldoc-jp/translation.git
  - kick deploy script
  
