### PR TITLE
JPRPのcvsリポジトリの更新を止める【OSDN.netにおいたCVSのGitHub移管完了後、マージする】

### DIFF
--- a/script/update.pl
+++ b/script/update.pl
@@ -35,20 +35,20 @@ if (! -d $assets_dir) {
     mkdir $assets_dir;
 }
 
-if (! $ENV{SKIP_ASSETS_UPDATE}) {
-    if (! -d $assets_dir . '/perldoc.jp/') {
-
-        mkdir $assets_dir . '/perldoc.jp/';
-        system(<<_SHELL_);
-    cd $assets_dir/perldoc.jp;
-    cvs -d:pserver:anonymous\@cvs.sourceforge.jp:/cvsroot/perldocjp login;
-    cvs -z3 -d:pserver:anonymous\@cvs.sourceforge.jp:/cvsroot/perldocjp co docs;
-_SHELL_
-
-    } else {
-        system(qq{cd $assets_dir/perldoc.jp/docs/; cvs up -dP});
-    }
-}
+#if (! $ENV{SKIP_ASSETS_UPDATE}) {
+#    if (! -d $assets_dir . '/perldoc.jp/') {
+#
+#        mkdir $assets_dir . '/perldoc.jp/';
+#        system(<<_SHELL_);
+#    cd $assets_dir/perldoc.jp;
+#    cvs -d:pserver:anonymous\@cvs.sourceforge.jp:/cvsroot/perldocjp login;
+#    cvs -z3 -d:pserver:anonymous\@cvs.sourceforge.jp:/cvsroot/perldocjp co docs;
+#_SHELL_
+#
+#    } else {
+#        system(qq{cd $assets_dir/perldoc.jp/docs/; cvs up -dP});
+#    }
+#}
 
 if (! -d $assets_dir . '/module-pod-jp/') {
     system(qq{git clone https://github.com/perldoc-jp/module-pod-jp.git $assets_dir/module-pod-jp/});


### PR DESCRIPTION

## 背景

- OSDN.net からGitHubに翻訳データが移管できた後、CVSリポジトリを参照して翻訳データを更新するのは止めたい
  - https://github.com/perldoc-jp/wg-perl-document/issues/25

## やったこと

- 翻訳データを更新している update.pl から該当箇所を削除

### やってないこと

- 関連コードの削除
