### PR TITLE
Moose-Doc-JAとMooseX-Getoptをtranslationにマージしたので、これらに関する分岐を削除

### DIFF
--- a/lib/PJP/M/Index/Module.pm
+++ b/lib/PJP/M/Index/Module.pm
@@ -58,8 +58,6 @@ sub generate {
     # 情報をかきあつめる
     my @mods;
     for my $base (map { File::Spec->catdir( $c->assets_dir(), $_) } qw(
-        Moose-Doc-JA/
-        MooseX-Getopt-Doc-JA/
         translation/docs/modules/
     )) {
         push @mods, $class->_generate($c, $base);

--- a/lib/PJP/M/PodFile.pm
+++ b/lib/PJP/M/PodFile.pm
@@ -22,13 +22,7 @@ sub slurp {
     my ($cnt) = $c->dbh->selectrow_array(q{SELECT COUNT(*) FROM pod WHERE path=?}, {}, $path);
     return undef unless $cnt;
 
-    my ($fullpath);
-    if ($path =~s{modules/(Moose[^/]*)}{$1}) {
-        my $module_name = $1;
-        ($fullpath) = glob(catdir($c->assets_dir(), $module_name . '-Doc-JA', $path));
-    } else {
-        ($fullpath) = glob(catdir($c->assets_dir(), '*', 'docs', $path));
-    }
+    my ($fullpath) = glob(catdir($c->assets_dir(), '*', 'docs', $path));
     return undef unless -f $fullpath;
 
     open my $fh, '<', $fullpath or die "Cannot open file: $fullpath";
@@ -155,10 +149,7 @@ sub generate {
 
         my $txn = $c->dbh_master->txn_scope();
         $c->dbh_master->do(q{DELETE FROM pod});
-        my @bases = (glob(catdir($c->assets_dir(), '*', 'docs')),
-                     glob(catdir($c->assets_dir(), 'Moose-Doc-JA')),
-                     glob(catdir($c->assets_dir(), 'MooseX-Getopt-Doc-JA')),
-                    );
+        my @bases = (glob(catdir($c->assets_dir(), '*', 'docs')));
         for my $base (@bases) {
                 my $repository = $base;
                 my $extention_exp;

--- a/lib/PJP/M/Repository.pm
+++ b/lib/PJP/M/Repository.pm
@@ -46,7 +46,7 @@ sub recent_data {
       }
   }em;
 
-  foreach my $repos (qw/Moose-Doc-JA MooseX-Getopt-Doc-JA translation/) {
+  foreach my $repos (qw/translation/) {
       foreach my $file (File::Find::Rule->file()->name(qr/\.(pod|html|md)$/)->in("$assets_dir$repos")) {
           my $git = qx{cd $assets_dir/$repos/; git log -1 --date=iso --pretty='%cd -- %an' --since='$date' $file} or next;
           my ($date, $time, $author) = $git =~m{^(\d{4}-\d{2}-\d{2})( \d{2}:\d{2}:\d{2}) \+\d{4} -- (.+)$} or die $git;

--- a/script/update.pl
+++ b/script/update.pl
@@ -58,16 +58,6 @@ if (! $ENV{SKIP_ASSETS_UPDATE}) {
     system(qq{cd $assets_dir/translation; git pull origin master});
 }
 
-foreach my $jpa_module (qw/MooseX-Getopt-Doc-JA  Moose-Doc-JA/) {
-    if (! -d $assets_dir . "/$jpa_module/") {
-	system(qq{cd $assets_dir; git clone https://github.com/jpa/$jpa_module.git});
-    }
-
-    if (! $ENV{SKIP_ASSETS_UPDATE}) {
-	system(qq{cd $assets_dir/$jpa_module; git pull origin master});
-    }
-}
-
 unlink "$assets_dir/index-module.pl";
 unlink "$assets_dir/index-article.pl";
 

--- a/tmpl/pod.tt
+++ b/tmpl/pod.tt
@@ -44,10 +44,6 @@
             <div class="Edit"><a target="_blank" href="https://github.com/perldoc-jp/translation/blob/master/docs/[% path %]">編集(github)</a></div>
             <div><a target="_blank" href="https://github.com/perldoc-jp/translation/commits/master/docs/[% path %]">変更履歴(github)</a></div>
             <div><a target="_blank" href="https://github.com/perldoc-jp/translation/issues/new?title=[% distvname | url %][% "の誤訳の報告" | url %]">誤訳の報告</a></div>
-            [% ELSIF repository=="Moose-Doc-JA" || repository=="MooseX-Getopt-Doc-JA" %]
-            [% github_path = path.replace('^modules/', '')%]
-            <div><a target="_blank" href="https://github.com/jpa/Moose-Doc-JA/commits/master/[% github_path %]">変更履歴(github)</a></div>
-            <div><a target="_blank" href="https://github.com/jpa/Moose-Doc-JA/issues/new?title=[% distvname | url %][% "の誤訳の報告" | url %]">誤訳の報告</a></div>
             [% ELSE %]
             <div><a target="_blank"  href="https://osdn.net/cvs/view/perldocjp/docs/[% path %]?view=log">変更履歴(sf.jp)</a></div>
             <div><a target="_blank" href="https://osdn.net/ticket/newticket.php?group_id=136">誤訳の報告</a></div>


### PR DESCRIPTION
件名の通り、Moose-Doc-JAとMooseX-Getoptをtranslationリポジトリに以下のPRにてマージしたので、
これらのリポジトリ用の特別な分岐を削除する。

- https://github.com/perldoc-jp/translation/pull/110
- https://github.com/perldoc-jp/translation/pull/109

削除が漏れてないことの確認は、以下の通り行なった

```shell
❯ rg 'Moose-' | wc -l
       0

~/src/github.com/perldoc-jp/perldoc.jp merged-Moose-and-MooseX-docs
❯ rg 'MooseX-' | wc -l
       0
```
