### PR TITLE
index/articleを実行時キャッシュにする

### DIFF
--- a/lib/PJP/Cache.pm
+++ b/lib/PJP/Cache.pm
@@ -38,6 +38,7 @@ sub get_or_set {
 
     $val = $cb->();
     $self->{cache}->set($key, $val, $xt || '1 day');
+    return $val;
 }
 
 1;

--- a/lib/PJP/M/Index/Article.pm
+++ b/lib/PJP/M/Index/Article.pm
@@ -36,30 +36,12 @@ sub cache_path {
     return catfile($c->assets_dir(), 'index-article.pl');
 }
 
-sub generate_and_save {
-    my ($class, $c) = @_;
-
-    my $fname = $class->cache_path($c);
-
-    my @data = $class->generate($c);
-    local $Data::Dumper::Terse  = 1;
-    local $Data::Dumper::Indent = 1;
-    local $Data::Dumper::Purity = 1;
-
-    open my $fh, '>', $fname;
-    print $fh Dumper(\@data);
-    close $fh;
-
-    return;
-}
-
 sub generate {
     my ($class, $c) = @_;
 
     # 情報をかきあつめる
     my @files;
     for my $base (map { File::Spec->catdir( $c->assets_dir(), $_) } qw(
-        perldoc.jp/docs/articles/
         translation/docs/articles/
     )) {
         push @files, $class->_get_files($c, $base) if -d $base;

--- a/lib/PJP/M/Index/Article.pm
+++ b/lib/PJP/M/Index/Article.pm
@@ -20,22 +20,6 @@ use Data::Dumper;
 use Regexp::Common qw/URI/;
 use PJP::Util qw/slurp/;
 
-sub get {
-    my ($class, $c) = @_;
-
-    my $fname = $class->cache_path($c);
-    unless (-f $fname) {
-        die "Missing '$fname'";
-    }
-
-    return do $fname;
-}
-
-sub cache_path {
-    my ($class, $c) = @_;
-    return catfile($c->assets_dir(), 'index-article.pl');
-}
-
 sub generate {
     my ($class, $c) = @_;
 

--- a/lib/PJP/Web/Dispatcher.pm
+++ b/lib/PJP/Web/Dispatcher.pm
@@ -129,11 +129,11 @@ get '/index/module' => sub {
 get '/index/article' => sub {
     my $c = shift;
 
-    my $content = $c->cache->file_cache("index/article", PJP::M::Index::Article->cache_path($c), sub {
-        my $index = PJP::M::Index::Article->get($c);
+    my $content = $c->cache->get_or_set('index/article', sub {
+        my @index = PJP::M::Index::Article->generate($c);
         $c->create_view->render(
             'index/article.tt' => {
-                index => $index,
+                index => \@index,
             }
         );
     });

--- a/script/update.pl
+++ b/script/update.pl
@@ -52,7 +52,6 @@ if (! -e $sqlite_db) {
 }
 
 my $t = time;
-PJP::M::Index::Article->generate_and_save($pjp);
 PJP::M::Index::Module->generate_and_save($pjp);
 PJP::M::BuiltinFunction->generate($pjp);
 PJP::M::BuiltinVariable->generate($pjp);

--- a/tmpl/index/article.tt
+++ b/tmpl/index/article.tt
@@ -11,9 +11,6 @@
                 <tr>
                     <td nowrap="nowrap">
                         <a href="/docs/articles/[% v.distvname %]">[% v.name %]</a>
-                        [% IF v.repository=='translation' %]
-                            <img src="/static/img/github.png" width="16" height="16" />
-                        [% END %]
                     </td>
                     <td>[% url_to_link(v.abstract) %]</td>
                 </tr>


### PR DESCRIPTION
関連issue: 
- https://github.com/perldoc-jp/perldoc.jp/issues/48

## 概要

- GitHubActionへの移行の一環のPR
- cronでindexファイルを作成するよりは、index/articleへのリクエスト時にキャッシュする方が相性良さそう
- pushされたタイミングでindexファイルをコミットすることも考えたが、実行時キャッシュでことは足りると思った。