### PR TITLE
atan2を関数の候補に入れるように正規表現を微調整

### DIFF
--- a/lib/PJP/M/BuiltinFunction.pm
+++ b/lib/PJP/M/BuiltinFunction.pm
@@ -68,7 +68,7 @@ sub generate {
             while (<$fh>) {
                 $_encoding = $1 and next if !defined $_encoding && m{^=encoding\s+(.+)$};
                 s{E<sol>}{/}g;
-                my @names = m{C<(\-?[a-zA-Z_]+)(?:[^>]+)?>}g;
+                my @names = m{C<(\-?[a-zA-Z0-9_]+)(?:[^>]+)?>}g;
                 push @_candidate, map {s{^($OPS_REGEXP)(?:/+|/STRING/)$}{$1}; $_} @names;
             }
             close $fh;


### PR DESCRIPTION
## 背景
- atan2が関数の翻訳から漏れていた。https://github.com/perldoc-jp/translation/issues/116

## やったこと

関数リストを取り出す処理が、数字入りの関数名を考慮していなかったので、数字を含めても良いようにした。
結果、atan2も関数一覧のリストに入るようになった。

変更前後の差分を確かめると、atan2だけ追加された。

```
❯ diff sorted-functions.txt fixed.txt
34a35
> atan2
```