### PR TITLE
qx/STRING/ と qw/STRING/ のリンク先を、qx, qw に変更する

### DIFF
--- a/lib/PJP/M/TOC.pm
+++ b/lib/PJP/M/TOC.pm
@@ -91,7 +91,7 @@ sub render_function {
         foreach my $func (@{$Pod::Functions::Kinds{$type}}) {
             my $func_link = $func;
             $func_link =~ s{^(y|s|tr|m)///?$}{$1};
-            $func_link =~ s{^(q|qq|qr)/STRING/$}{$1};
+            $func_link =~ s{^(q|qq|qr|qx|qw)/STRING/$}{$1};
             if ($strlen > 40) {
                 $out .= "<br />\n";
                 $strlen = 0;


### PR DESCRIPTION
## 背景

- 関数一覧にて、 `qx/STRING/` と `qw/STRING/` が、リンク切れしている
  - https://github.com/perldoc-jp/translation/issues/117
  - https://github.com/perldoc-jp/translation/issues/118
- 似た `q/STRING/` や `qq/STRING/` は、https://perldoc.jp/func/q や https://perldoc.jp/func/qq にリンクされている

## やったこと

- `q/STRING/` や `qq/STRING/` と同様に、`qx/STRING/` と `qw/STRING/` のリンク先を、qx, qw に変更した。