### PR TITLE
関数一覧と変数一覧で、リンク切れしていないかテストする

### DIFF
--- a/t/endpoints.t
+++ b/t/endpoints.t
@@ -64,6 +64,9 @@ subtest 'GET /index/function' => sub {
     $mech->get('/index/function');
     is $mech->status, 200, 'status is 200';
     is $mech->title, 'Perlの組み込み関数の翻訳一覧 - perldoc.jp';
+
+    my @links = $mech->find_all_links( url_regex => qr[/func/] );
+    $mech->links_ok( \@links, 'Check all links for function links' );
 };
 
 subtest 'GET /index/variable' => sub {

--- a/t/endpoints.t
+++ b/t/endpoints.t
@@ -73,6 +73,9 @@ subtest 'GET /index/variable' => sub {
     $mech->get('/index/variable');
     is $mech->status, 200, 'status is 200';
     is $mech->title, 'Perlの組み込み変数の翻訳一覧 - perldoc.jp';
+
+    my @links = $mech->find_all_links( url_regex => qr[/variable/] );
+    $mech->links_ok( \@links, 'Check all links for variable links' );
 };
 
 subtest 'GET /index/module' => sub {


### PR DESCRIPTION
## 背景

- 次のPRによって、関数一覧は、リンク切れはなくなった。
  - https://github.com/perldoc-jp/perldoc.jp/pull/61
  - https://github.com/perldoc-jp/perldoc.jp/pull/60
- 今後リンク切れを起こすとしたら、翻訳がないケースやフォーマットが変わってしまったケース。
