### PR TITLE
index/coreもリンク切れがないかテストをする

### DIFF
--- a/t/endpoints.t
+++ b/t/endpoints.t
@@ -58,6 +58,9 @@ subtest 'GET /index/core' => sub {
     $mech->get('/index/core');
     is $mech->status, 200, 'status is 200';
     is $mech->title, 'Perlのコアドキュメントの翻訳一覧 - perldoc.jp';
+
+    my @links = $mech->find_all_links( url_regex => qr[/pod/] );
+    $mech->links_ok( \@links, 'Check all links for core document links' );
 };
 
 subtest 'GET /index/function' => sub {
@@ -66,7 +69,7 @@ subtest 'GET /index/function' => sub {
     is $mech->title, 'Perlの組み込み関数の翻訳一覧 - perldoc.jp';
 
     my @links = $mech->find_all_links( url_regex => qr[/func/] );
-    $mech->links_ok( \@links, 'Check all links for function links' );
+    $mech->links_ok( \@links, 'Check all links for function document links' );
 };
 
 subtest 'GET /index/variable' => sub {
@@ -75,7 +78,7 @@ subtest 'GET /index/variable' => sub {
     is $mech->title, 'Perlの組み込み変数の翻訳一覧 - perldoc.jp';
 
     my @links = $mech->find_all_links( url_regex => qr[/variable/] );
-    $mech->links_ok( \@links, 'Check all links for variable links' );
+    $mech->links_ok( \@links, 'Check all links for variable document links' );
 };
 
 subtest 'GET /index/module' => sub {


### PR DESCRIPTION
index/function や index/variable と同様に、ドキュメントから自動生成される index/coreもリンク切れがないかテストする。

補足：index/moduleや index/article は、翻訳があるものから自動でリンクが生成されているので、このテストを書いていない。