### PR TITLE
翻訳 pod の原文ブロックの div 開きタグが消える回帰を直す

### DIFF
--- a/lib/PJP/M/Pod.pm
+++ b/lib/PJP/M/Pod.pm
@@ -110,6 +110,24 @@ sub get_latest_file_path {
         return $self;
     }
 
+    # Pod::Simple::XHTML 3.29 (2015-02) で start_for が emit しなくなり、開いた
+    # <div class="original"> が scratch に残るようになった。start_Verbatim や
+    # start_over_* / _end_head は scratch を代入で上書きするため、その div が
+    # 消えて </div> だけが残る (=head が先頭に来たときは div が見出しの中へ
+    # 紛れ込み、TRANHEADSTART マーカーの置換まで壊す)。CPAN 最新の 3.48 でも
+    # 直っていないので、3.28 (旧 VPS の perl 5.18.2) と同じく、開いた時点で
+    # 流し切る。
+    sub start_for {
+        my ($self, $flags) = @_;
+        $self->SUPER::start_for($flags);
+        return if $self->__in_literal_xhtml_region;
+        # 3.28 は ">" までしか積まなかった。ここで末尾の改行を落としておくと、
+        # end_Document の join("\n\n", ...) が同じ位置に改行を戻すので、
+        # 1 回で emit していた頃と出力がバイト単位で一致する
+        $self->{scratch} =~ s/\s+\z//;
+        $self->emit;
+    }
+
     # for google source code prettifier
     sub start_Verbatim {
         $_[0]{'scratch'} = '<pre class="prettyprint lang-perl"><code>';

--- a/t/M/Pod.t
+++ b/t/M/Pod.t
@@ -55,18 +55,69 @@ subtest 'pod2html' => sub {
     subtest 'HTMLタグが閉じられてるか' => sub {
         my $html = PJP::M::Pod->pod2html("@{[$c->assets_dir]}translation/docs/perl/5.12.1/perl.pod");
 
-        todo 'pod2html', sub {
-            fail 'HTMLタグが閉じられているかのテストが失敗している';
-        };
+        # 一覧に nobr は入れない。<nobr> は Pod::Simple::HTML が S<> に対して
+        # 出すもので、Pod::Simple::XHTML は版に関係なく出さないため、
+        # ok $open > 0 に必ず落ちる
+        my $testee = $html;
+        for my $tag (qw/div pre p h1 h2 code b a ul li i/) {
+            my ($open, $close) = (0, 0);
+            $testee =~ s/<$tag[^>]*>/$open++/gei;
+            $testee =~ s!</$tag[^>]*>!$close++!gei;
+            ok $open > 0, "$tag があり、";
+            ok $open == $close, '開始タグと終了タグの数が一致している';
+        }
+    };
 
-        # my $testee = $html;
-        # for my $tag (qw/div pre p h1 h2 code b a ul li nobr i/) {
-        #     my ($open, $close) = (0, 0);
-        #     $testee =~ s/<$tag[^>]*>/$open++/gei;
-        #     $testee =~ s!</$tag[^>]*>!$close++!gei;
-        #     ok $open > 0, "$tag があり、";
-        #     ok $open == $close, '開始タグと終了タグの数が一致している';
-        # }
+    # Pod::Simple::XHTML 3.29 以降、start_for が開いた <div class="original"> は
+    # emit されずに scratch へ滞留する。原文ブロックの先頭が scratch を代入で
+    # 上書きする要素 (verbatim / =over / =head) だと開きタグだけが消え、
+    # </div> が余って DOM が壊れる。lib/PJP/M/Pod.pm の start_for override が
+    # 3.28 と同じく開いた時点で流し切ることで防いでいる
+    my %original_shape = (
+        verbatim => "    my \$x = 1;\n",
+        over     => "=over 4\n\n=item foo\n\nbar\n\n=back\n",
+        head     => "=head2 Some Heading\n\nbody\n",
+    );
+
+    subtest '原文ブロックの先頭がどの要素でも div が閉じきる' => sub {
+        for my $name (sort keys %original_shape) {
+            subtest $name => sub {
+                my $pod = "=encoding utf-8\n\n=head1 NAME\n\nSample - $name\n\n"
+                        . "=begin original\n\n$original_shape{$name}\n=end original\n\n訳文。\n";
+                my $html = PJP::M::Pod->pod2html(\$pod);
+                my $open  = () = $html =~ /<div/g;
+                my $close = () = $html =~ m{</div>}g;
+                is $open, $close, '<div> と </div> の数が一致する';
+                like $html, qr{<div class="original">}, '原文ブロックの開きタグがある';
+            };
+        }
+    };
+
+    subtest '原文ブロックの先頭が見出しでも見出しのマーカーが漏れない' => sub {
+        # =head が先頭だと _end_head が滞留中の div ごと見出しテキストとして
+        # 取り込み、end_Document の TRANHEADSTART...TRANHEADEND の置換が改行を
+        # またげずに失敗してマーカーが本文に出る。div の数だけ見ると釣り合って
+        # しまうので、独立して確かめる。
+        # 見出しは必ず中身のあるものにすること — 空の =head1 は (.+?) が
+        # 空文字にマッチしない別の既知バグ (Net/Netrc.pod) を踏む
+        my $pod = "=encoding utf-8\n\n=head1 NAME\n\nSample - head\n\n"
+                . "=begin original\n\n$original_shape{head}\n=end original\n\n"
+                . "=head2 とある見出し\n\n訳文。\n";
+        my $html = PJP::M::Pod->pod2html(\$pod);
+        unlike $html, qr/TRANHEAD(?:START|END)/, 'マーカーが出力に残らない';
+        unlike $html, qr{<li><a href="[^"]*"><div}, '目次のリンク文字列に div が混ざらない';
+    };
+
+    subtest '=begin html は literal region のまま扱う' => sub {
+        # literal xhtml region では start_for が early return するので、
+        # 3.29 以降の挙動 (div を出さない) を変えない
+        my $pod = "=encoding utf-8\n\n=head1 NAME\n\nSample - html\n\n"
+                . "=begin html\n\n<b>raw</b>\n\n=end html\n\n訳文。\n";
+        my $html = PJP::M::Pod->pod2html(\$pod);
+        my $open  = () = $html =~ /<div/g;
+        my $close = () = $html =~ m{</div>}g;
+        is $open, $close, '<div> と </div> の数が一致する';
+        unlike $html, qr{<div class="html">}, 'literal region に div を足さない';
     };
 };
 


### PR DESCRIPTION
## 何が起きていたか

staging (Cloud Run) の POD ページだけ、原文ブロックを包む `<div class="original">` の
**開きタグが欠落し、対応する `</div>` だけが残っていた**。過剰な `</div>` が祖先要素を
早期に閉じるため DOM が崩れ、`div.original` の非表示指定が子孫セレクタなので原文が
出しっぱなしになる。

```
$ curl -s https://perldoc.jp/func/-B         | grep -o '</\?div' | sort | uniq -c   # 37 / 37
$ curl -s https://staging.perldoc.jp/func/-B | grep -o '</\?div' | sort | uniq -c   # 30 / 37
```

影響は `/func/*`, `/variable/*`, `/docs/**.pod` の全 POD ページ (すべて `PJP::M::Pod->pod2html` 経由)。

## 原因

`Pod::Simple::XHTML` の `start_for` は **3.28 では `<div class="…">` を積んだ直後に `emit`
していたが、3.29 (2015-02) 以降 `emit` しなくなり**、開きタグが `{scratch}` に滞留する
ようになった。滞留中に `{scratch}` を**代入で上書き**するハンドラが走ると開きタグは捨てられ、
`end_for` が必ず出す `</div>` だけが残る。

| ハンドラ | 対応する POD |
|---|---|
| `start_Verbatim` (基底クラス・override の両方) | インデント行 |
| `start_over_bullet` / `_block` / `_number` / `_text` | `=over` |
| `_end_head` (override) | `=head1`〜`=head4` |

perl 5.18.2 (Pod::Simple 3.28) → 5.42 (3.45) の移行で踏んだもの。`cpanfile` は
`requires 'Pod::Simple', '3.16'` と下限しか書いておらず、core モジュールなので
snapshot にも載らない。**CPAN 最新の 3.48 でも上流未修正**なので (3.29〜3.48 で
`start_for` の本文は完全に同一、ChangeLog にも記載なし)、アプリ側で 3.28 と同じ挙動に戻す。

### もう 1 つの症状

原文ブロックの先頭が `=head` のとき、`_end_head` が滞留中の div ごと見出しテキストとして
取り込むため、`end_Document` の `s[TRANHEADSTART(.+?)TRANHEADEND]` が `/s` 無しで改行を
またげずに失敗し、**マーカー文字列がページに漏れていた**。div の数は釣り合うので均衡
チェックでは検出できない。同じ根本原因なのでこの修正で一緒に直る。

```
$ curl -s https://staging.perldoc.jp/docs/modules/Config-Pit-0.04/Pit.pod | grep -o TRANHEADSTART | wc -l  # 1
$ curl -s https://perldoc.jp/docs/modules/Config-Pit-0.04/Pit.pod         | grep -o TRANHEADSTART | wc -l  # 0
```

## 直し方

`PJP::Pod::Parser` に `start_for` の override を足し、開きタグを積んだ時点で flush する。
`{scratch}` を空にしてから下位ハンドラへ渡すので、上表のどのハンドラが先頭に来ても壊れない。

`s/\s+\z//` で末尾の改行を落とすのは、`end_Document` の `join("\n\n", …)` が同じ位置に
改行を戻すため。これにより 1 回で emit していた頃と出力がバイト単位で一致する。
`=begin html` のような literal xhtml region は早期 return して既存挙動を変えない。

個々のハンドラを `.=` に直して回る案は採らなかった。`start_Verbatim` だけ直しても
`=over` / `=head` 先頭のケースが残るうえ、基底クラス側の代入は直せない。

## 検証

`assets/translation/docs` の全 2484 pod をレンダリングして計測:

| | 修正前 | 修正後 |
|---|---|---|
| `<div>` と `</div>` の不均衡 | 805 pod / 7730 個 | **0** |
| `TRANHEADSTART` の漏れ | 16 pod / 39 箇所 | **1 pod / 1 箇所** |

残る 1 件は `libnet-1.12/Net/Netrc.pod` の**空の `=head1`** による別のバグ (`(.+?)` が
空文字にマッチしない)。**旧本番でも同じく漏れている**ので回帰ではなく、スコープ外とした。

**副作用チェック** — 全 2484 pod を修正前後で MD5 比較:

- 症状の影響を受けない 1679 pod のうち **1674 pod は出力がバイト単位で完全に一致**
- 残る 5 pod (`Config-Pit`, `Data-Validator`, `Furl` ×3) は上記マーカー漏れが消えた分のみ

**旧本番との突き合わせ** — バイト比較はできない (旧 VPS は現 master より古いコードを
動かしており、現 master の `end_Document` が使う `encode_url` は 3.28 に存在しない) ため、
アンカー修正が触らない div の個数で照合した:

| ページ | 旧本番 | staging | 差 | ローカルの復元数 |
|---|---|---|---|---|
| `/docs/perl/5.12.1/perl.pod` | 103 | 74 | 29 | 55 → 84 (**+29**) |
| `/docs/perl/5.38.0/perlintro.pod` | 151 | 123 | 28 | 104 → 132 (**+28**) |

復元される個数が参照実装との差と完全に一致する。

**テストスイート**: Docker 上で 14 ファイル / 135 テスト すべて PASS。

## テストの復活

`t/M/Pod.t` の「HTMLタグが閉じられてるか」は 2023-12 の 2a2f532 で todo 化 +
均衡チェックがコメントアウトされ、この回帰を隠していた。当時落ちていた原因は
`nobr` (`Pod::Simple::HTML` 専用で XHTML は版を問わず出さない) と、**まさに今回直す
`div` の不均衡**の 2 つ。todo を外すのは、当時本来直すべきだったバグをいま直すからで、
期待値を緩めるからではない。

あわせて assets に依存しない fixture で、原文ブロックの先頭が verbatim / `=over` /
`=head` の 3 形状と、`=begin html` が literal region のままであることを押さえた。

## デプロイ後の確認

`/func` `/variable` `/docs` の HTML は databuild ステージで SQLite に焼き込まれるため、
反映にはイメージの再ビルドが必要 (デプロイパイプラインが自動で行う)。

```bash
curl -s https://staging.perldoc.jp/func/-B | grep -o '</\?div' | sort | uniq -c   # 37 / 37 になる
curl -s https://staging.perldoc.jp/docs/modules/Config-Pit-0.04/Pit.pod | grep -o TRANHEADSTART | wc -l   # 0 になる
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
