### PR TITLE
サイト内・外部リンクの URL を https に統一する

### DIFF
--- a/lib/PJP/M/BuiltinFunction.pm
+++ b/lib/PJP/M/BuiltinFunction.pm
@@ -177,8 +177,8 @@ sub generate {
 
         push @functions, $name;
         my $pod = join("", "=encoding $encoding\n\n=over 4\n\n", @dynamic_pod, "\n\n=back\n");
-        $pod =~ s!L</([a-z]+)>!L<$1|http://perldoc.jp/func/$1>!g;
-        $pod =~ s!L<C<([a-z]+|__[A-Z]+__)(>\|/\1(?: .+?)?)>!L<$1|http://perldoc.jp/func/$1>!g;
+        $pod =~ s!L</([a-z]+)>!L<$1|https://perldoc.jp/func/$1>!g;
+        $pod =~ s!L<C<([a-z]+|__[A-Z]+__)(>\|/\1(?: .+?)?)>!L<$1|https://perldoc.jp/func/$1>!g;
         my $html = PJP::M::Pod->pod2html(\$pod);
         $c->dbh_master->insert(
                                func => {

--- a/lib/PJP/M/BuiltinVariable.pm
+++ b/lib/PJP/M/BuiltinVariable.pm
@@ -94,7 +94,7 @@ sub generate {
 
 	push @variables, $name;
         my $pod = join("", "=encoding $encoding\n\n=over 4\n\n", @dynamic_pod, "=back\n");
-        $pod =~ s!L</([a-z]+)>!L<$1|http://perldoc.jp/variable/$1>!g;
+        $pod =~ s!L</([a-z]+)>!L<$1|https://perldoc.jp/variable/$1>!g;
         my $html = PJP::M::Pod->pod2html(\$pod);
 	$c->dbh_master->insert(
 			       var => {

--- a/script/create_data.pl
+++ b/script/create_data.pl
@@ -89,7 +89,7 @@ sub create_rss {
     my $rss = XML::RSS->new(version => '2.0');
     $rss->channel(
         title          => 'perldoc.jp',
-        link           => 'http://perldoc.jp/',
+        link           => 'https://perldoc.jp/',
         language       => 'ja',
         description    => 'Perl の公式ドキュメント、モジュールを日本語翻訳したものを表示するサイトです。',
         copyright      => 'Japan Perl Association',
@@ -103,7 +103,7 @@ sub create_rss {
         my $datetime = Time::Piece->strptime($module->{date}, '%Y-%m-%d %H:%M:%S');
         $rss->add_item(
             title       => $module->{name},
-            link        => "http://perldoc.jp/" . $module->{path},
+            link        => "https://perldoc.jp/" . $module->{path},
             description => ($module->{in} ? "$module->{in}の" : '') . "$module->{name}" . ($module->{version} ? "($module->{version})": '') . "が、$module->{author} により commit されました。",
             pubDate     => PJP::M::Repository::format_rfc822_jst($datetime),
             );

--- a/tmpl/404.tt
+++ b/tmpl/404.tt
@@ -2,7 +2,7 @@
 [% IF is_hash_ref(message) && message.package %]
    [% message.package %]はみつかりませんでした。
    <div>
-   <a href="http://metacpan.org/module/[% message.package %]">MetaCPANで見る</a>
+   <a href="https://metacpan.org/pod/[% message.package %]">MetaCPANで見る</a>
    </div>
 [% ELSIF is_hash_ref(message) && defined message.query %]
    「[% message.query %]」の検索結果が見つかりませんでした。

--- a/tmpl/about.tt
+++ b/tmpl/about.tt
@@ -34,7 +34,7 @@ Discordのサーバーを用意しています。次のリンクから気軽に�
 <h2>運営・管理</h2>
 
 <p>
-このサイト(perldoc.jp)は、<a href="http://japan.perlassociation.org/">Japan Perl Association</a>(JPA)が管理しています。<br />
+このサイト(perldoc.jp)は、<a href="https://japan.perlassociation.org/">Japan Perl Association</a>(JPA)が管理しています。<br />
 翻訳は、有志により行われています。
 </p>
 
@@ -50,7 +50,7 @@ miyagawaさんが最初に始めたものを tokuhiromさんが引き継ぎ、�
     <dd>miyagawaさんがperldoc.jpを始められるまでは、翻訳を閲覧できる場所がCVSのリポジトリしかありませんでした。</dt>
     <dt>tokuhiromさん</dt>
     <dd>miyagawaさんから引き継ぎ、新規にコードを書き上げられました。現在のサイトもほぼtokuhiromさんのコードで動いています。</dt>
-    <dt><a href="http://josdc.github.com/">Japan Open Source Design Committee(JOSDC)</a></dt>
+    <dt><a href="https://josdc.github.com/">Japan Open Source Design Committee(JOSDC)</a></dt>
     <dd>JPA管理になった際に、サイトデザインをしていただきました。</dt>
 </dl>
 

--- a/tmpl/index/module.tt
+++ b/tmpl/index/module.tt
@@ -1,5 +1,5 @@
 <div class="content">
-    <p class="about">CPAN モジュールのドキュメントです。英語版は <a href="http://search.cpan.org/">search.cpan.org</a>でみることができます</p>
+    <p class="about">CPAN モジュールのドキュメントです。英語版は <a href="https://metacpan.org/">metacpan.org</a>でみることができます</p>
 
     <div class="IndexModuleContainer">
         <h1>翻訳済 CPAN モジュール</h1>

--- a/tmpl/layout.html
+++ b/tmpl/layout.html
@@ -10,7 +10,7 @@
     <meta name="description" content="[% IF description %][% description %][% ELSE %]このサイトはPerlの公式ドキュメント、モジュールのドキュメントを日本語に翻訳したものを表示するサイトです。[% END %]" />
     <meta name="keywords" content="Perl,翻訳,モジュール">
     [% IF top_page %]
-    <link rel="alternate" type="application/rss+xml" title="perldoc.jp 最近の更新" href="http://perldoc.jp/static/rss/recent.rss" />
+    <link rel="alternate" type="application/rss+xml" title="perldoc.jp 最近の更新" href="https://perldoc.jp/static/rss/recent.rss" />
     [% END %]
     <link href="/static/css/screen.css" media="screen, projection" rel="stylesheet" type="text/css" />
     [% IF diff_page %]
@@ -34,7 +34,7 @@
 
         (function() {
             var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-            ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+            ga.src = 'https://ssl.google-analytics.com/ga.js';
             var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
         })();
     </script>
@@ -70,7 +70,7 @@
             <div id="content">[% content %]</div>
         </div>
         <div class="footer span-24 last">
-            Powered by Amon2, <a href="https://github.com/perldoc-jp/translation">翻訳</a>, <a href="https://github.com/perldoc-jp/perldoc.jp">サイト</a>. Operated by <a href="http://japan.perlassociation.org">Japan Perl Association</a>
+            Powered by Amon2, <a href="https://github.com/perldoc-jp/translation">翻訳</a>, <a href="https://github.com/perldoc-jp/perldoc.jp">サイト</a>. Operated by <a href="https://japan.perlassociation.org">Japan Perl Association</a>
         </div>
     </div>
 </body>

--- a/tmpl/pod.tt
+++ b/tmpl/pod.tt
@@ -15,7 +15,7 @@
         <div class="PodInfo">
             <div class="PodVersion">[% PodVersion %]</div>
         [% IF package && ! is_article  %]
-            <div class="CheckAtCPAN"><a href="http://search.cpan.org/perldoc?[% package %]">CPANで確認する</a></div>
+            <div class="CheckAtCPAN"><a href="https://metacpan.org/pod/[% package %]">CPANで確認する</a></div>
         [% END %]
         [% IF ! is_article AND others AND others.size() > 0 %]
             <div class="OtherVersions">


### PR DESCRIPTION
## 背景

本番 (VPS) と staging (Cloud Run) の全エンドポイント比較で、staging では本文中のリンクが `http://` のまま配信されていることが分かった。VPS 版はエッジ (Cloudflare の Automatic HTTPS Rewrites とみられる) が href/src 属性の `http://` を `https://` に書き換えて配信していたため問題が見えなかったが、Worker 経由の staging にはこの書き換えが効かない。エッジの挙動に依存せず、生成側で https に統一する。

## 変更内容

- **自サイトリンク**
  - `BuiltinFunction` / `BuiltinVariable` が生成する `http://perldoc.jp/func|variable/...` を https に (databuild で DB に焼き込まれるため、反映には再ビルドが必要)
  - RSS の channel/item link (`script/create_data.pl`) と layout の RSS alternate リンクを https に
- **外部リンク**
  - JPA (japan.perlassociation.org) を https に (https で 200 を返すことを確認済み)
  - search.cpan.org は廃止済み (https は metacpan.org へ 301) のため metacpan.org へ置換。404 ページの MetaCPAN リンクも https + 現行の `/pod/` 形式に
  - GA ローダのスキーム分岐を https 固定に (エッジで Always Use HTTPS が有効なため http ページは存在しない)
- josdc.github.com は http/https とも 502 で到達不能だが、リンク先自体の見直しは別件とし、ここではスキームのみ揃えた

## 検証

- `make ci` (docker compose 上の prove) で 14 ファイル・135 テスト全パス
- lib/ tmpl/ script/create_data.pl に `http://` の残存が無いことを grep で確認
- `https://metacpan.org/pod/Acme::Bleach` など置換先 URL が 200 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)