### PR TITLE
本番イメージのビルドを Cloud Build へ移す

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,7 @@ docs/
 README.md
 Makefile
 docker-compose.yml
+cloudbuild.yaml
 terraform/
 worker/
 inc/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,15 +15,148 @@ concurrency:
   group: deploy
   cancel-in-progress: true
 
-# permissions はジョブレベルで宣言する。WIF の資格情報を扱う deploy ジョブには
-# contents: write を与えず、リポジトリへの書き込みは commit-years-data ジョブに分離する
+# permissions はジョブレベルで宣言する。リポジトリへ書き込む years ジョブと、
+# WIF の資格情報を扱う deploy ジョブを分け、どちらにも両方を持たせない
 jobs:
-  deploy:
+  # data/years.pl をビルドの前に更新する。
+  #
+  # PJP::M::YearData->build は対象年 (translation の最新イベントの前年) より前を
+  # 既存の data/years.pl から seed としてそのまま引き継ぎ、対象年以降だけを
+  # git 履歴から再構築する。この書き戻しが無いと、ある年が再導出の窓から外れた
+  # 時点でその年の統計がシードのコミット時点で凍結される。
+  #
+  # ビルドより前に置いて、その結果のコミットをビルドのソースにする。こうすると
+  # 「master にコミットされている years.pl」と「イメージが読む years.pl」が
+  # 構造的に一致し、成果物をビルドから取り出して GitHub へ運ぶ経路が要らなくなる。
+  #
+  # GITHUB_TOKEN による push は GitHub の再帰防止によりワークフローを
+  # 再トリガーしないため、デプロイのループは起きない。
+  years:
     runs-on: ubuntu-latest
-    # このジョブ自身はビルドせず Cloud Build の完了を待つだけになったが、待ち時間の
+    # 生成に要るのは translation の git 履歴と既存の data/years.pl だけで DB は
+    # 触らないが、script/create_data.pl は冒頭で PJP::M を useall するため CPAN
+    # 依存一式が要る。ubuntu-latest の system perl とは版が合わないので、
+    # Dockerfile の base と同じイメージの中で走らせる
+    container: perl:5.42-trixie
+    timeout-minutes: 45
+    permissions:
+      contents: write
+    outputs:
+      # ビルドのソースにするコミット。書き戻しが無い run や、競合で捨てた run では
+      # github.sha のまま
+      app-sha: ${{ steps.years.outputs.app-sha }}
+      # years.pl の再導出とイメージのビルドで同じ translation を見るために、
+      # 解決した SHA を deploy ジョブへ渡す
+      translation-sha: ${{ steps.translation.outputs.sha }}
+
+    steps:
+      # 外部 action はコミット SHA にピン留めする (この workflow は WIF の
+      # デプロイ資格情報と master への書き込み権限を扱うため、タグの付け替えに
+      # よる改竄の影響を受けないようにする)。更新時は SHA とコメントのバージョンを
+      # 両方書き換えること
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Resolve translation HEAD
+        id: translation
+        run: |
+          sha=$(git ls-remote https://github.com/perldoc-jp/translation.git refs/heads/master | cut -f1)
+          # 値は Cloud Build の substitution として別のシステムへ渡るので、
+          # 「空でない」より強く形式そのものを確かめる。bash の =~ は文字列全体に
+          # 対して照合するので、複数行が紛れ込んでも通らない
+          [[ "$sha" =~ ^[0-9a-f]{40}$ ]]
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      # cpanfile.snapshot が変わらない限り再利用する。Deploy は日次 schedule で
+      # 動くので、7 日の未使用による eviction には基本かからない
+      - name: Restore CPAN dependencies
+        id: deps
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: local
+          key: perl-deps-5.42-trixie-${{ hashFiles('cpanfile.snapshot') }}
+
+      # Dockerfile の base / deps ステージと同じ手順。cpm --resolver snapshot は
+      # Carton::Snapshot を require するので Carton が先に要る。
+      # perl:5.42-trixie は buildpack-deps 由来で gcc/g++/make と各種 dev ライブラリを
+      # 持つが、Dockerfile と同じ集合を明示して XS のビルド条件を揃える
+      - name: Install CPAN dependencies
+        if: steps.deps.outputs.cache-hit != 'true'
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends wget gcc g++ make sqlite3 git
+          cpm install -g Carton
+          cpm install --resolver snapshot --no-default-resolvers --show-build-log-on-failure
+
+      # create_data.pl が全履歴の git log を使うため、コミット履歴付き
+      # (blob は checkout 分のみ) で取得する。Dockerfile の databuild と同じ
+      - name: Fetch translation
+        env:
+          TRANSLATION_SHA: ${{ steps.translation.outputs.sha }}
+        run: |
+          rm -rf assets/translation
+          git clone --filter=blob:none https://github.com/perldoc-jp/translation.git assets/translation
+          git -C assets/translation checkout --quiet "$TRANSLATION_SHA"
+
+      # config/build.pl は Dockerfile と同じ /usr/src/app の絶対パスを前提にして
+      # いる (assets_dir)。設定を CI 用に分岐させず、イメージの中と同じ配置を作って
+      # そこで走らせる。git 操作は symlink を通さず既定の作業ディレクトリで行う
+      - name: Regenerate data/years.pl
+        env:
+          PLACK_ENV: build
+          PERL5LIB: /usr/src/app/local/lib/perl5
+        run: |
+          rm -rf /usr/src/app
+          ln -s "$GITHUB_WORKSPACE" /usr/src/app
+          cd /usr/src/app
+          perl script/update-years.pl
+          test -s data/years.pl
+
+      # 差分があれば master へ書き戻し、ビルドのソースにする SHA を出力する
+      - name: Commit data/years.pl if changed
+        id: years
+        run: |
+          if git diff --quiet -- data/years.pl; then
+            echo 'data/years.pl: no changes'
+            echo "app-sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add data/years.pl
+          git commit -m 'data/years.pl を最新の再導出結果で更新する'
+
+          # if 複合コマンドの直後の $? は if 自身の終了状態 (0) になるので、
+          # push の終了状態は || で明示的に捕まえる
+          push_status=0
+          git push origin HEAD:master || push_status=$?
+          if [ "$push_status" -eq 0 ]; then
+            echo "app-sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # push の失敗をすべて競合として扱うと、権限不足・branch protection・
+          # 通信障害まで成功扱いになる。remote が生成元から動いたことを
+          # 確かめられたときだけ捨てる。捨てた場合は github.sha のままビルドする
+          # (master が進んだということは後続の run があり、書き戻しはそちらに任せる)
+          git fetch --no-tags origin master || exit "$push_status"
+          remote=$(git rev-parse FETCH_HEAD)
+          if [ "$remote" != "$GITHUB_SHA" ]; then
+            echo "master has moved to $remote; dropping this run's data/years.pl"
+            echo "app-sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo 'push failed although master did not advance' >&2
+          exit "$push_status"
+
+  deploy:
+    needs: years
+    runs-on: ubuntu-latest
+    # このジョブ自身はビルドせず Cloud Build の完了を待つだけだが、待ち時間の
     # 内訳は「Cloud Build の queue 待ち (cloudbuild.yaml の timeout には含まれない)
-    # + ビルド最大 60 分 + years.pl 取得 + デプロイ」。ビルドは e2-standard-2 (2 vCPU)
-    # で走り ubuntu-latest (4 vCPU) より遅いことも織り込んで余裕を取る
+    # + ビルド最大 60 分 + デプロイ」。ビルドは e2-standard-2 (2 vCPU) で走り
+    # ubuntu-latest (4 vCPU) より遅いことも織り込んで余裕を取る
     timeout-minutes: 90
     permissions:
       contents: read
@@ -45,36 +178,35 @@ jobs:
       # 既に両方を渡している
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       IMAGE: asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/perldoc-jp/app
-      # Cloud Build 用の識別子はどちらも既存の secret から組み立てる。
-      # project ID の重複保存を避けるため、専用の secret / variable は追加しない
+      # Cloud Build 用の識別子は既存の secret から組み立てる。project ID の
+      # 重複保存を避けるため、専用の secret / variable は追加しない
       # (§7 の分類と WIF provider / SA email の扱いに合わせる)
       BUILDER_SA: perldoc-jp-builder@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
-      ARTIFACT_BUCKET: ${{ secrets.GCP_PROJECT_ID }}-build-artifacts
       # Cloud Build が source を fetch する先。公開リポジトリなので connection も
       # 資格情報も要らない (docs/cloud-run.md §11)
       SOURCE_REPO: https://github.com/${{ github.repository }}
+      # ビルドするコミット。years ジョブが書き戻していればその commit、
+      # 書き戻しが無ければ github.sha
+      APP_SHA: ${{ needs.years.outputs.app-sha }}
       # Starlet のワーカー数。Cloud Run の container concurrency と一致させる
       # (デフォルト 80 では 4 ワーカーに大量のリクエストが詰まる)。両方へ同じ値を
       # 渡すことで、一致がコメント頼みでなくなる
       STARLET_MAX_WORKERS: '4'
       # イメージのタグは run ごとに一意にする。schedule / workflow_dispatch
-      # (translation 通知) では github.sha が変わらないまま中身の異なるイメージ
+      # (translation 通知) では commit が変わらないまま中身の異なるイメージ
       # (translation 更新分) が作られるため、sha だけのタグはビルドを特定できない
-      # (run_id は re-run で同一になるため run_attempt まで含める)。
-      # Cloud Build へ渡す years.pl のオブジェクト名にもこの値を使う
-      TAG: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+      # (run_id は re-run で同一になるため run_attempt まで含める)
+      TAG: ${{ needs.years.outputs.app-sha }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
-      # 外部 action はコミット SHA にピン留めする (この workflow は WIF の
-      # デプロイ資格情報を扱うため、タグの付け替えによる改竄の影響を受けない
-      # ようにする)。更新時は SHA とコメントのバージョンを両方書き換えること
-      #
       # ビルドコンテキストは Cloud Build が自分で fetch するが、gcloud は
       # --config のファイルを手元から読んで Build を組み立てる。つまり
-      # cloudbuild.yaml はこの checkout から来る。どちらも github.sha なので
-      # 一致する
+      # cloudbuild.yaml はこの checkout から来るので、Cloud Build が fetch する
+      # commit と同じものを取る
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.years.outputs.app-sha }}
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
@@ -90,38 +222,26 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
-      # translation の HEAD を build-arg に渡し、translation が更新された
-      # ときだけ databuild ステージのキャッシュを無効化する
-      - name: Resolve translation HEAD
-        id: translation
-        run: |
-          sha=$(git ls-remote https://github.com/perldoc-jp/translation.git refs/heads/master | cut -f1)
-          # 値は Cloud Build の substitution として別のシステムへ渡るので、
-          # 「空でない」より強く形式そのものを確かめる。bash の =~ は文字列全体に
-          # 対して照合するので、複数行が紛れ込んでも通らない
-          [[ "$sha" =~ ^[0-9a-f]{40}$ ]]
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
-
-      # ビルド・テスト・smoke test・years-export は Cloud Build (asia-northeast1) で
-      # 行う (cloudbuild.yaml)。GitHub-hosted runner が Artifact Registry から
+      # ビルド・テスト・smoke test は Cloud Build (asia-northeast1) で行う
+      # (cloudbuild.yaml)。GitHub-hosted runner が Artifact Registry から
       # buildcache や runtime イメージを取得すると、そのたびにインターネットへの
       # data transfer out になるため。
       #
       # source はローカルの checkout を送らず、公開リポジトリの exact commit SHA を
       # Cloud Build 自身に fetch させる。Cloud Storage の staging bucket に
-      # ソースが溜まる構成を避けつつ、GitHub 側の checkout と Cloud Build が
-      # ビルドする commit を一致させる (ブランチ名ではなく github.sha を使う)
+      # ソースが溜まる構成を避けつつ、ビルドする commit を明示的に固定する
+      # (ブランチ名は使わない)
       - name: Submit build to Cloud Build
         env:
           # 外部 Git リモートから実行時に得た値を shell のソース本文へ埋め込まない。
           # step の env 経由なら、値は shell 変数として渡り、構文として
           # 再解釈されない
-          TRANSLATION_SHA: ${{ steps.translation.outputs.sha }}
+          TRANSLATION_SHA: ${{ needs.years.outputs.translation-sha }}
         run: |
           build_id=$(gcloud builds submit "$SOURCE_REPO" \
             --project "$GCP_PROJECT_ID" \
             --region "$REGION" \
-            --git-source-revision "$GITHUB_SHA" \
+            --git-source-revision "$APP_SHA" \
             --config cloudbuild.yaml \
             --service-account "projects/$GCP_PROJECT_ID/serviceAccounts/$BUILDER_SA" \
             --substitutions "_TAG=$TAG,_TRANSLATION_COMMIT=$TRANSLATION_SHA" \
@@ -185,8 +305,7 @@ jobs:
       # concurrency の cancel-in-progress は translation 通知が連続すると
       # 日常的に発火するため、取りこぼさないようにする。
       # failure() も拾うのは、ジョブの timeout-minutes 超過や待機ステップ自身の
-      # 失敗でもビルドが走り続けるため。すでに終端状態のビルドに cancel を投げると
-      # gcloud がエラーを返すが、それは || true で無視してよい
+      # 失敗でもビルドが走り続けるため
       - name: Cancel Cloud Build
         if: cancelled() || failure()
         run: |
@@ -240,23 +359,6 @@ jobs:
             echo "https://console.cloud.google.com/cloud-build/builds;region=$REGION/$CLOUD_BUILD_ID"
           }
 
-      # ビルドで再導出された data/years.pl を Cloud Build から受け取る。
-      # GitHub へ戻すのはこの 1 MB 未満のファイルだけで、Artifact Registry から
-      # runner へレイヤを引く経路は残さない。
-      #
-      # デプロイより前に置いて取得後すぐ削除する。デプロイが失敗しても
-      # オブジェクトが残らない (取りこぼしはバケットの lifecycle が 1 日で回収する)
-      - name: Fetch data/years.pl from Cloud Build
-        run: |
-          object="gs://$ARTIFACT_BUCKET/years/$TAG.pl"
-          mkdir -p years-out
-          gcloud storage cp "$object" years-out/years.pl
-          test -s years-out/years.pl
-          # 取得は済んでいるので、消せなかっただけでデプロイを止めない
-          # (残っても lifecycle が 1 日で回収する)
-          gcloud storage rm "$object" \
-            || echo 'years.pl のオブジェクトを削除できなかった (lifecycle が回収する)'
-
       # サービス設定を毎回明示し、デプロイの実行順序に依存せず
       # self-correcting にする。
       #
@@ -286,81 +388,3 @@ jobs:
             --set-env-vars "STARLET_MAX_WORKERS=$STARLET_MAX_WORKERS" \
             --timeout 60 --port 8080 \
             --quiet
-
-      # commit-years-data ジョブへ渡す。デプロイ成功後に置いているのは、
-      # smoke test やデプロイで失敗した run に artifact を残さないため (v4 の
-      # artifact は immutable なので、残っていると失敗ジョブの re-run が同名
-      # artifact への upload で衝突して二重に失敗する)
-      - name: Upload data/years.pl
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: years-data
-          path: years-out/years.pl
-          retention-days: 1
-          # 「Re-run all jobs」ではデプロイ成功済み run の artifact が残っている
-          overwrite: true
-
-  # デプロイ成功後、ビルドで再導出された data/years.pl に変更があれば master へ
-  # 自動コミットする。
-  #
-  # databuild が git から再導出するのは前年+当年だけなので、この書き戻しが
-  # 無いと、ある年の統計は 2 年後にシードのコミット時点の内容で凍結されて
-  # しまう (docs/cloud-run.md の「運用」参照)。
-  #
-  # GITHUB_TOKEN による push は GitHub の再帰防止によりワークフローを
-  # 再トリガーしないため、デプロイのループは起きない。その代わり translation の
-  # 更新が連続すると、seed は次の更新か日次 schedule まで古いままになりうる。
-  # デプロイ済みのイメージは各 run が再導出した正しい内容なので、この遅延は受容する。
-  commit-years-data:
-    needs: deploy
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # artifact の生成元と commit の親を一致させる。最新の master に
-          # 対してコミットすると、この run が生成した years.pl を、別の
-          # コミットのコードから導出したかのように載せることになる
-          ref: ${{ github.sha }}
-
-      # deploy ジョブが同一 run に upload した artifact を受け取る
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: years-data
-          path: years-out
-
-      - name: Commit data/years.pl if changed
-        run: |
-          cp years-out/years.pl data/years.pl
-          if git diff --quiet -- data/years.pl; then
-            echo 'data/years.pl: no changes'
-            exit 0
-          fi
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add data/years.pl
-          git commit -m 'data/years.pl を最新の再導出結果で更新する'
-
-          # if 複合コマンドの直後の $? は if 自身の終了状態 (0) になるので、
-          # push の終了状態は || で明示的に捕まえる
-          push_status=0
-          git push origin HEAD:master || push_status=$?
-          if [ "$push_status" -eq 0 ]; then
-            exit 0
-          fi
-
-          # push の失敗をすべて競合として扱うと、権限不足・branch protection・
-          # 通信障害まで成功扱いになる。remote が生成元から動いたことを
-          # 確かめられたときだけ捨てる
-          git fetch --no-tags origin master || exit "$push_status"
-          remote=$(git rev-parse FETCH_HEAD)
-          if [ "$remote" != "$GITHUB_SHA" ]; then
-            echo "master has moved to $remote; dropping this run's artifact"
-            exit 0
-          fi
-          echo 'push failed although master did not advance' >&2
-          exit "$push_status"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,9 +38,19 @@ jobs:
     # 依存一式が要る。ubuntu-latest の system perl とは版が合わないので、
     # Dockerfile の base と同じイメージの中で走らせる
     container: perl:5.42-trixie
+    # コンテナジョブの run は既定が sh になる (bash ではない)。ここは [[ ]] を使う
     timeout-minutes: 45
     permissions:
       contents: write
+    # このジョブは master へ直接 push する。environment の deployment branch policy を
+    # master 限定にすることで、workflow_dispatch で別の ref を選んでもジョブ開始前に
+    # 拒否される。secret は置かず、ref を絞るためだけの environment
+    # (§7)。以前は書き込みが deploy の後段にあり、gcp-production の branch policy が
+    # 間接的にこの境界を担っていたが、ビルドの前に移したので自前で持つ必要がある
+    environment: master-write
+    defaults:
+      run:
+        shell: bash
     outputs:
       # ビルドのソースにするコミット。書き戻しが無い run や、競合で捨てた run では
       # github.sha のまま
@@ -116,6 +126,14 @@ jobs:
       - name: Commit data/years.pl if changed
         id: years
         run: |
+          # environment master-write の branch policy がこの run を master に
+          # 限定している。environment は参照されただけでも branch policy 無しで
+          # 自動作成されるため、設定漏れに黙って通されないようここでも確かめる。
+          # yml 内の検査は workflow_dispatch では yml ごと差し替えられるので
+          # 境界にはならない。境界は environment 側で、これはその設定漏れに
+          # 気づくための保険 (§7)
+          test "$GITHUB_REF" = 'refs/heads/master'
+
           if git diff --quiet -- data/years.pl; then
             echo 'data/years.pl: no changes'
             echo "app-sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,11 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # このジョブ自身はビルドせず Cloud Build の完了を待つだけになったが、待ち時間の
+    # 内訳は「Cloud Build の queue 待ち (cloudbuild.yaml の timeout には含まれない)
+    # + ビルド最大 60 分 + years.pl 取得 + デプロイ」。ビルドは e2-standard-2 (2 vCPU)
+    # で走り ubuntu-latest (4 vCPU) より遅いことも織り込んで余裕を取る
+    timeout-minutes: 90
     permissions:
       contents: read
       id-token: write
@@ -41,6 +45,14 @@ jobs:
       # 既に両方を渡している
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       IMAGE: asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/perldoc-jp/app
+      # Cloud Build 用の識別子はどちらも既存の secret から組み立てる。
+      # project ID の重複保存を避けるため、専用の secret / variable は追加しない
+      # (§7 の分類と WIF provider / SA email の扱いに合わせる)
+      BUILDER_SA: perldoc-jp-builder@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+      ARTIFACT_BUCKET: ${{ secrets.GCP_PROJECT_ID }}-build-artifacts
+      # Cloud Build が source を fetch する先。公開リポジトリなので connection も
+      # 資格情報も要らない (docs/cloud-run.md §11)
+      SOURCE_REPO: https://github.com/${{ github.repository }}
       # Starlet のワーカー数。Cloud Run の container concurrency と一致させる
       # (デフォルト 80 では 4 ワーカーに大量のリクエストが詰まる)。両方へ同じ値を
       # 渡すことで、一致がコメント頼みでなくなる
@@ -48,17 +60,21 @@ jobs:
       # イメージのタグは run ごとに一意にする。schedule / workflow_dispatch
       # (translation 通知) では github.sha が変わらないまま中身の異なるイメージ
       # (translation 更新分) が作られるため、sha だけのタグはビルドを特定できない
-      # (run_id は re-run で同一になるため run_attempt まで含める)
+      # (run_id は re-run で同一になるため run_attempt まで含める)。
+      # Cloud Build へ渡す years.pl のオブジェクト名にもこの値を使う
       TAG: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       # 外部 action はコミット SHA にピン留めする (この workflow は WIF の
       # デプロイ資格情報を扱うため、タグの付け替えによる改竄の影響を受けない
       # ようにする)。更新時は SHA とコメントのバージョンを両方書き換えること
+      #
+      # ビルドコンテキストは Cloud Build が自分で fetch するが、gcloud は
+      # --config のファイルを手元から読んで Build を組み立てる。つまり
+      # cloudbuild.yaml はこの checkout から来る。どちらも github.sha なので
+      # 一致する
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
@@ -74,47 +90,172 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
-      - run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
-
       # translation の HEAD を build-arg に渡し、translation が更新された
       # ときだけ databuild ステージのキャッシュを無効化する
       - name: Resolve translation HEAD
         id: translation
         run: |
           sha=$(git ls-remote https://github.com/perldoc-jp/translation.git refs/heads/master | cut -f1)
-          test -n "$sha"
+          # 値は Cloud Build の substitution として別のシステムへ渡るので、
+          # 「空でない」より強く形式そのものを確かめる。bash の =~ は文字列全体に
+          # 対して照合するので、複数行が紛れ込んでも通らない
+          [[ "$sha" =~ ^[0-9a-f]{40}$ ]]
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        # build record artifact と job summary には build inputs (project ID 入りの
-        # image tag / cache 参照) がそのまま入る。§7 の分類ではどちらも出せない
-        # (artifact は公開リポジトリでは実質公開で、secret マスクも効かない)
+      # ビルド・テスト・smoke test・years-export は Cloud Build (asia-northeast1) で
+      # 行う (cloudbuild.yaml)。GitHub-hosted runner が Artifact Registry から
+      # buildcache や runtime イメージを取得すると、そのたびにインターネットへの
+      # data transfer out になるため。
+      #
+      # source はローカルの checkout を送らず、公開リポジトリの exact commit SHA を
+      # Cloud Build 自身に fetch させる。Cloud Storage の staging bucket に
+      # ソースが溜まる構成を避けつつ、GitHub 側の checkout と Cloud Build が
+      # ビルドする commit を一致させる (ブランチ名ではなく github.sha を使う)
+      - name: Submit build to Cloud Build
         env:
-          DOCKER_BUILD_RECORD_UPLOAD: 'false'
-          DOCKER_BUILD_SUMMARY: 'false'
-        with:
-          context: .
-          target: runtime
-          push: true
-          tags: ${{ env.IMAGE }}:${{ env.TAG }}
-          build-args: |
-            TRANSLATION_COMMIT=${{ steps.translation.outputs.sha }}
-          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
-          # registry cache は次のデプロイと years-export のため、gha cache は
-          # PR の runtime-test のために書く (PR からは WIF が要る registry を
-          # 読めない)。runtime-test は push では回らないので、gha の
-          # scope=runtime を書けるのはこのジョブだけになる。schedule や
-          # translation 通知のビルドでも温まる
-          cache-to: |
-            type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max
-            type=gha,mode=max,scope=runtime
+          # 外部 Git リモートから実行時に得た値を shell のソース本文へ埋め込まない。
+          # step の env 経由なら、値は shell 変数として渡り、構文として
+          # 再解釈されない
+          TRANSLATION_SHA: ${{ steps.translation.outputs.sha }}
+        run: |
+          build_id=$(gcloud builds submit "$SOURCE_REPO" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$REGION" \
+            --git-source-revision "$GITHUB_SHA" \
+            --config cloudbuild.yaml \
+            --service-account "projects/$GCP_PROJECT_ID/serviceAccounts/$BUILDER_SA" \
+            --substitutions "_TAG=$TAG,_TRANSLATION_COMMIT=$TRANSLATION_SHA" \
+            --async --format='value(id)')
+          [[ "$build_id" =~ ^[0-9a-f][0-9a-f-]{7,}$ ]]
+          echo "CLOUD_BUILD_ID=$build_id" >> "$GITHUB_ENV"
+          echo "Cloud Build: $build_id"
+          echo "https://console.cloud.google.com/cloud-build/builds;region=$REGION/$build_id"
 
-      # 本番同等の構成 (PLACK_ENV=deployment・immutable DSN・slim イメージ) は
-      # databuild の prove (PLACK_ENV=build) では検証されないため、push した
-      # イメージを Cloud Run 相当の FS 制約で起動して開通確認してからデプロイする
-      - name: Smoke test image
-        run: ./script/smoke-test.pl "$IMAGE:$TAG"
+      # --async で投げたので、完了は自分で待つ。cloudbuild.yaml は
+      # logging: CLOUD_LOGGING_ONLY を使っており、そもそもビルドログの
+      # live streaming ができないため、同期実行にしても得るものがない。
+      # 逆に build ID を先に手に入れておくと、この run がキャンセルされたときに
+      # Cloud Build 側も止められる (下の Cancel ステップ)
+      - name: Wait for Cloud Build
+        run: |
+          err="$RUNNER_TEMP/cloud-build-describe.err"
+          failures=0
+          while :; do
+            # stderr は混ぜない。gcloud が終了コード 0 のまま警告を 1 行でも出すと
+            # $status が SUCCESS と一致しなくなり、成功したビルドを捨ててしまう
+            if status=$(gcloud builds describe "$CLOUD_BUILD_ID" \
+                 --project "$GCP_PROJECT_ID" --region "$REGION" \
+                 --format='value(status)' 2>"$err"); then
+              failures=0
+            else
+              # 一時的な API エラーで数十分のビルドを捨てない。続けて失敗する
+              # ようなら諦める
+              failures=$((failures + 1))
+              if [ "$failures" -ge 5 ]; then
+                echo 'gcloud builds describe が 5 回続けて失敗した:' >&2
+                cat "$err" >&2
+                exit 1
+              fi
+              sleep 15
+              continue
+            fi
+
+            case "$status" in
+              SUCCESS)
+                echo 'Cloud Build: SUCCESS'
+                exit 0
+                ;;
+              QUEUED | WORKING | STATUS_UNKNOWN | PENDING)
+                sleep 15
+                ;;
+              *)
+                # FAILURE / TIMEOUT / CANCELLED / EXPIRED / INTERNAL_ERROR。
+                # ここで落とすことで、以降の Cloud Run デプロイには進まない
+                echo "Cloud Build が失敗した: $status" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+      # この run がキャンセルされても Cloud Build 側は走り続ける。放置すると
+      # 「もう誰も使わないイメージの push」「無料枠 build-minutes の空費」に加え、
+      # 新旧 2 本のビルドが同じ :buildcache タグへ mode=max で書くことになり、
+      # last-writer-wins で古い方の cache manifest が残って以後のヒット率が下がる
+      # (キャッシュが壊れてビルドが失敗するわけではない)。
+      # concurrency の cancel-in-progress は translation 通知が連続すると
+      # 日常的に発火するため、取りこぼさないようにする。
+      # failure() も拾うのは、ジョブの timeout-minutes 超過や待機ステップ自身の
+      # 失敗でもビルドが走り続けるため。すでに終端状態のビルドに cancel を投げると
+      # gcloud がエラーを返すが、それは || true で無視してよい
+      - name: Cancel Cloud Build
+        if: cancelled() || failure()
+        run: |
+          # CLOUD_BUILD_ID の有無で判断しない。Cloud Build は作成要求を受理した
+          # 時点でビルドを開始し、その応答が返って $GITHUB_ENV に ID が書かれるまでには
+          # 隙間がある。この間にキャンセルされると ID は空のままだが、ビルドは
+          # 走り続ける。この run の TAG は substitution として全ビルドに載っているので、
+          # ID ではなくそれで未完了のビルドを引き直す (--ongoing は QUEUED と WORKING
+          # だけを返すので、すでに終わったビルドに cancel を投げることもない)
+          if ids=$(gcloud builds list \
+              --project "$GCP_PROJECT_ID" --region "$REGION" \
+              --ongoing --limit 50 \
+              --filter="substitutions._TAG=$TAG" \
+              --format='value(id)'); then
+            :
+          else
+            # list が落ちたときだけ、保存できていれば ID にフォールバックする。
+            # 「list も失敗し、ID も保存されていない」場合だけは回収できないので、
+            # そのときは Cloud Console か下のコマンドで手動で止める
+            # (docs/cloud-run.md の「運用」参照)
+            echo 'gcloud builds list に失敗した。保存済みの ID を使う' >&2
+            ids=${CLOUD_BUILD_ID:-}
+          fi
+
+          ids=$(printf '%s\n' "$ids" | sed '/^$/d')
+          if [ -z "$ids" ]; then
+            echo '進行中の Cloud Build は無い'
+            exit 0
+          fi
+          for id in $ids; do
+            echo "cancelling Cloud Build: $id"
+            gcloud builds cancel "$id" \
+              --project "$GCP_PROJECT_ID" --region "$REGION" || true
+          done
+
+      # CLOUD_LOGGING_ONLY のビルドログは Cloud Logging から読む。deployer SA に
+      # roles/logging.viewer が無い場合はここが失敗するが、ビルドの成否は
+      # 直前のステップで確定済みなので握りつぶし、Console の URL を案内するに留める
+      - name: Show Cloud Build log
+        if: always()
+        run: |
+          if [ -z "${CLOUD_BUILD_ID:-}" ]; then
+            # submit が ID を返す前に中断された場合はここに来る。ビルド自体が
+            # 走っていた可能性はあるが、その回収は Cancel ステップが TAG で行う
+            echo 'Cloud Build の ID を保存できていないためログを取得しない'
+            exit 0
+          fi
+          gcloud builds log "$CLOUD_BUILD_ID" \
+            --project "$GCP_PROJECT_ID" --region "$REGION" || {
+            echo 'ビルドログを取得できなかった (roles/logging.viewer 未付与など)。'
+            echo "https://console.cloud.google.com/cloud-build/builds;region=$REGION/$CLOUD_BUILD_ID"
+          }
+
+      # ビルドで再導出された data/years.pl を Cloud Build から受け取る。
+      # GitHub へ戻すのはこの 1 MB 未満のファイルだけで、Artifact Registry から
+      # runner へレイヤを引く経路は残さない。
+      #
+      # デプロイより前に置いて取得後すぐ削除する。デプロイが失敗しても
+      # オブジェクトが残らない (取りこぼしはバケットの lifecycle が 1 日で回収する)
+      - name: Fetch data/years.pl from Cloud Build
+        run: |
+          object="gs://$ARTIFACT_BUCKET/years/$TAG.pl"
+          mkdir -p years-out
+          gcloud storage cp "$object" years-out/years.pl
+          test -s years-out/years.pl
+          # 取得は済んでいるので、消せなかっただけでデプロイを止めない
+          # (残っても lifecycle が 1 日で回収する)
+          gcloud storage rm "$object" \
+            || echo 'years.pl のオブジェクトを削除できなかった (lifecycle が回収する)'
 
       # サービス設定を毎回明示し、デプロイの実行順序に依存せず
       # self-correcting にする。
@@ -146,25 +287,10 @@ jobs:
             --timeout 60 --port 8080 \
             --quiet
 
-      # ビルドで再導出された data/years.pl を取り出し、commit-years-data ジョブが
-      # master へ書き戻せるよう artifact に置く。デプロイ成功後に置いているのは、
+      # commit-years-data ジョブへ渡す。デプロイ成功後に置いているのは、
       # smoke test やデプロイで失敗した run に artifact を残さないため (v4 の
       # artifact は immutable なので、残っていると失敗ジョブの re-run が同名
-      # artifact への upload で衝突して二重に失敗する)。Build and push image が
-      # 書いた registry buildcache を明示的に参照するため、builder のローカル状態
-      # (GC 等) に関わらず databuild が再実行されることはない
-      - name: Export data/years.pl
-        # 外部 Git リモートから実行時に得た値を shell のソース本文へ埋め込まない。
-        # step の env 経由なら、値は shell 変数として渡り、構文として
-        # 再解釈されない
-        env:
-          TRANSLATION_SHA: ${{ steps.translation.outputs.sha }}
-        run: |
-          docker buildx build --target years-export \
-            --build-arg "TRANSLATION_COMMIT=$TRANSLATION_SHA" \
-            --cache-from type=registry,ref=$IMAGE:buildcache \
-            --output type=local,dest=years-out .
-
+      # artifact への upload で衝突して二重に失敗する)
       - name: Upload data/years.pl
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,23 +121,6 @@ jobs:
         cache-from: type=gha,scope=runtime-pr
         cache-to: type=gha,mode=max,scope=runtime-pr
 
-    # years-export は runtime から参照されないので、上のビルドでは作られない。
-    # 本番では Cloud Build が smoke test の後にこのステージを作り、失敗すれば
-    # デプロイまで到達しない (以前はデプロイ成功後に GitHub Actions 側で
-    # 作っていたため、壊れていても「本番へ反映された後に years.pl の書き戻しだけが
-    # 失敗する」形だった)。それでも PR で先に気づけるほうが手戻りは小さい。
-    # runtime と同じ translation SHA・同じキャッシュで作るので、ここでの
-    # 追加ビルドはほぼ全レイヤがキャッシュに当たる
-    - name: Build years-export stage
-      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-      with:
-        context: .
-        target: years-export
-        outputs: type=cacheonly
-        build-args: |
-          TRANSLATION_COMMIT=${{ steps.translation.outputs.sha }}
-        cache-from: type=gha,scope=runtime-pr
-
     - name: Smoke test image
       run: ./script/smoke-test.pl perldocjp-runtime:latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,10 +74,9 @@ jobs:
   # ビルドして smoke test まで回す。translation は deploy.yml と同じく HEAD の
   # SHA に固定し、キャッシュの無効化を translation の更新に連動させる。
   #
-  # push では回さない。master への push では deploy.yml が同じ runtime を
-  # ビルドして同じ smoke test を回すため、ここで回すと同一イメージを 2 回
-  # (しかも互いに読めない別のキャッシュで) 作ることになる。gha キャッシュへの
-  # 書き込みは deploy.yml が引き継ぐ
+  # push では回さない。master への push では Cloud Build (cloudbuild.yaml) が
+  # 同じ runtime をビルドして同じ smoke test を回すため、ここで回すと同一
+  # イメージを 2 回 (しかも互いに読めない別のキャッシュで) 作ることになる
   runtime-test:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -97,13 +96,19 @@ jobs:
         echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
     # キャッシュの scope を app イメージと分け、mode=max の書き込みが互いの
-    # レイヤを追い出さないようにする。deploy.yml の registry cache は WIF の
-    # 認証を要するため PR (fork を含む) からは読めず、ここでは使わない。
-    # scope=runtime は deploy.yml (master push) が書く共有キャッシュ。
-    # lib/ や script/ を触る PR は databuild レイヤがそこに無いため、
-    # runtime-pr にも書いて同じ PR への連続 push でフルビルドを繰り返さない
-    # ようにする (gha キャッシュは PR 単位に隔離されるので、読めるのは
-    # 同じ PR の前回分だけ)
+    # レイヤを追い出さないようにする。
+    #
+    # 本番ビルドが Cloud Build へ移ったため、gha キャッシュを書くジョブはもう無い
+    # (以前は deploy.yml の master ビルドが scope=runtime を共有キャッシュとして
+    # 温めていた)。Cloud Build が使う Artifact Registry の registry cache は WIF の
+    # 認証を要するので PR (fork を含む) からは読めず、読ませもしない: PR に GCP の
+    # 資格情報を渡さないため、そして Artifact Registry から GitHub-hosted runner への
+    # data transfer out を復活させないため。
+    #
+    # 結果としてここが読めるのは、同じ PR の前回 push が書いた runtime-pr だけになる
+    # (gha キャッシュは PR 単位に隔離される)。PR の初回ビルドは base (apt + Carton)
+    # から databuild (pod2html) までフルで回ることになるが、security とコストを
+    # 優先してこの劣化は受容する
     - name: Build runtime image
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
@@ -113,14 +118,14 @@ jobs:
         load: true
         build-args: |
           TRANSLATION_COMMIT=${{ steps.translation.outputs.sha }}
-        cache-from: |
-          type=gha,scope=runtime
-          type=gha,scope=runtime-pr
+        cache-from: type=gha,scope=runtime-pr
         cache-to: type=gha,mode=max,scope=runtime-pr
 
     # years-export は runtime から参照されないので、上のビルドでは作られない。
-    # deploy.yml はデプロイが成功した後にこのステージを使うため、壊れていても
-    # 「本番へ反映された後に years.pl の書き戻しだけが失敗する」形になる。
+    # 本番では Cloud Build が smoke test の後にこのステージを作り、失敗すれば
+    # デプロイまで到達しない (以前はデプロイ成功後に GitHub Actions 側で
+    # 作っていたため、壊れていても「本番へ反映された後に years.pl の書き戻しだけが
+    # 失敗する」形だった)。それでも PR で先に気づけるほうが手戻りは小さい。
     # runtime と同じ translation SHA・同じキャッシュで作るので、ここでの
     # 追加ビルドはほぼ全レイヤがキャッシュに当たる
     - name: Build years-export stage
@@ -131,9 +136,7 @@ jobs:
         outputs: type=cacheonly
         build-args: |
           TRANSLATION_COMMIT=${{ steps.translation.outputs.sha }}
-        cache-from: |
-          type=gha,scope=runtime
-          type=gha,scope=runtime-pr
+        cache-from: type=gha,scope=runtime-pr
 
     - name: Smoke test image
       run: ./script/smoke-test.pl perldocjp-runtime:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,8 +138,9 @@ COPY app.psgi toc.txt toc-var.txt ./
 RUN prove -lr t/ && touch /tests-passed
 
 
-# years-export: deploy.yml の commit-years-data ジョブが、ビルドで再導出された
-# data/years.pl を取り出して master へ書き戻すための export 専用ステージ。
+# years-export: ビルドで再導出された data/years.pl を master へ書き戻すための
+# export 専用ステージ。Cloud Build (cloudbuild.yaml) がこのステージから取り出し、
+# deploy.yml の commit-years-data ジョブがコミットする。
 # (databuild が git から再導出するのは前年+当年だけなので、書き戻しが無いと
 # ある年の統計は 2 年後にシードのコミット時点の内容で凍結されてしまう)
 FROM scratch AS years-export
@@ -178,7 +179,8 @@ COPY --from=deps /usr/src/app/local ./local
 # 配信イメージは COPY . . (denylist) にしない。CI のワークスペースに落ちた
 # ファイル (google-github-actions/auth の gha-creds-*.json 等) を .dockerignore の
 # 列挙漏れひとつで拾ってしまうため、実行時に読むものだけを列挙する。
-# 列挙漏れは deploy.yml の smoke test が検出する (toc.txt → /index/core など)
+# 列挙漏れは smoke test が検出する (toc.txt → /index/core など)。
+# 本番は Cloud Build (cloudbuild.yaml)、PR は test.yml がこれを回す
 COPY app.psgi toc.txt toc-var.txt ./
 COPY config ./config
 COPY lib ./lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,16 +138,6 @@ COPY app.psgi toc.txt toc-var.txt ./
 RUN prove -lr t/ && touch /tests-passed
 
 
-# years-export: ビルドで再導出された data/years.pl を master へ書き戻すための
-# export 専用ステージ。Cloud Build (cloudbuild.yaml) がこのステージから取り出し、
-# deploy.yml の commit-years-data ジョブがコミットする。
-# (databuild が git から再導出するのは前年+当年だけなので、書き戻しが無いと
-# ある年の統計は 2 年後にシードのコミット時点の内容で凍結されてしまう)
-FROM scratch AS years-export
-
-COPY --from=databuild /usr/src/app/data/years.pl /years.pl
-
-
 # runtime: Cloud Run 用。レイヤは変更頻度の低い順に重ね、DB を最後に置く。
 FROM perl:5.42-slim-trixie AS runtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,13 +106,13 @@ RUN SKIP_ASSETS_UPDATE=1 perl script/update.pl
 # 更新しないため、この位置でも仕上がりの DB は変わらない
 RUN sqlite3 db/perldocjp.db 'PRAGMA page_size = 8192; VACUUM; ANALYZE;'
 
-# 年次統計の seed (data/years.pl)。デプロイのたびに自動コミットされるため、
-# update.pl より下に置いて pod2html のレイヤキャッシュを壊さないようにする
+# 年次統計 (data/years.pl) はここで再生成せず、コミットされている現物をそのまま
+# イメージへ入れる。再導出はビルドより前に deploy.yml の years ジョブが行い、
+# その結果のコミットがこのビルドのソースになる (create_data.pl の冒頭を参照)。
+# デプロイのたびに自動コミットされる最も揮発的な入力なので、update.pl より下に
+# 置いて pod2html のレイヤキャッシュを壊さないようにする
 COPY data ./data
 
-# 対象年 (translation の最新イベントの前年) は script 側で導出する。
-# 壁時計から取るとコマンド文字列が入力に依らず一定のため、年をまたいでも
-# キャッシュされたレイヤが再利用され、対象年が古いまま進まない
 RUN perl script/create_data.pl
 
 RUN rm -rf assets/translation/.git db/perldocjp.master.db

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,11 @@ ci:
 
 # 翻訳データと、それに依存する生成物のセットアップ。
 # 本番の Dockerfile databuild ステージと同じ生成物を作る
-# (data/recent.pl, data/years.pl, static/docs.json,
+# (data/recent.pl, static/docs.json,
 #  data/index-module.pl, data/index-article.pl)。
+# data/years.pl は databuild でも作らない (ビルドより前に
+# script/update-years.pl が再導出してコミットする)。手元で更新したい場合は
+# docker compose exec app perl script/update-years.pl を別途実行する。
 .PHONY: setup-data
 setup-data:
 	docker compose exec app perl script/update.pl

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,11 +1,14 @@
 # 本番イメージのビルドを Cloud Build (asia-northeast1) で行うための設定。
 # .github/workflows/deploy.yml が exact commit SHA を指定して submit する。
 #
-# GitHub-hosted runner でビルドしていた頃は、buildcache の pull・smoke test の
-# ための image pull・years-export の cache pull がすべて Artifact Registry から
-# インターネットへ出る転送になっていた。build から smoke test・years-export までを
-# 同じリージョンの Cloud Build に寄せることで、レイヤ転送を asia-northeast1 内に
-# 閉じ込める (同一ロケーション内の転送は無料)。
+# GitHub-hosted runner でビルドしていた頃は、buildcache の pull と smoke test の
+# ための image pull がどちらも Artifact Registry からインターネットへ出る転送に
+# なっていた。build から smoke test までを同じリージョンの Cloud Build に寄せる
+# ことで、レイヤ転送を asia-northeast1 内に閉じ込める (同一ロケーション内は無料)。
+#
+# data/years.pl はここでは扱わない。deploy.yml の years ジョブが、このビルドに
+# 渡すのと同じ translation の SHA で再導出して master へコミットし、その commit を
+# ソースにしてビルドする。イメージが読むのはそのコミット済みの現物になる
 #
 # Cloud Run への deploy はここでは行わない。GitHub Actions 側の Workload Identity
 # Federation が持つ境界 (master かつ deploy.yml からのみ認証できる) を維持するため、
@@ -198,50 +201,3 @@ steps:
       - |
         export PATH=/ci/bin:$$PATH
         exec ./script/smoke-test.pl "$$IMAGE:$$TAG"
-
-  # ビルドで再導出された data/years.pl を取り出す。deploy.yml の commit-years-data が
-  # master へ書き戻すために使う (databuild が git から再導出するのは前年+当年だけなので、
-  # 書き戻しが無いとある年の統計は 2 年後にシードのコミット時点の内容で凍結される)。
-  #
-  # 同じ builder のローカルキャッシュに全レイヤが載っているので実質即時に終わる。
-  # registry の cache-from は、builder のローカル状態 (GC 等) に関わらず databuild が
-  # 再実行されないようにするための保険。--platform を runtime と揃えないと
-  # 別のビルドグラフになりキャッシュに当たらない
-  - id: years-export
-    name: 'gcr.io/cloud-builders/gcloud'
-    entrypoint: 'bash'
-    volumes:
-      - name: 'ci'
-        path: '/ci'
-    env:
-      - 'DOCKER_CONFIG=/ci/docker'
-      - 'IMAGE=asia-northeast1-docker.pkg.dev/$PROJECT_ID/perldoc-jp/app'
-      - 'TRANSLATION_COMMIT=${_TRANSLATION_COMMIT}'
-    args:
-      - -ceu
-      - |
-        export PATH=/ci/bin:$$PATH
-        docker buildx build --builder perldocjp \
-          --target years-export \
-          --platform linux/amd64 \
-          --build-arg "TRANSLATION_COMMIT=$$TRANSLATION_COMMIT" \
-          --cache-from "type=registry,ref=$$IMAGE:buildcache" \
-          --output "type=local,dest=/ci/years-out" \
-          .
-
-  # GitHub Actions へ渡すのは 1 MB 未満のこのファイルだけ。オブジェクト名は
-  # deploy.yml が組み立てた run ごとに一意な TAG で、GitHub 側が取得後に削除する
-  # (取りこぼしはバケットの lifecycle が 1 日で回収する)
-  - id: upload-years
-    name: 'gcr.io/cloud-builders/gcloud'
-    entrypoint: 'bash'
-    volumes:
-      - name: 'ci'
-        path: '/ci'
-    env:
-      - 'OBJECT=gs://$PROJECT_ID-build-artifacts/years/${_TAG}.pl'
-    args:
-      - -ceu
-      - |
-        test -s /ci/years-out/years.pl
-        gcloud storage cp /ci/years-out/years.pl "$$OBJECT"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,247 @@
+# 本番イメージのビルドを Cloud Build (asia-northeast1) で行うための設定。
+# .github/workflows/deploy.yml が exact commit SHA を指定して submit する。
+#
+# GitHub-hosted runner でビルドしていた頃は、buildcache の pull・smoke test の
+# ための image pull・years-export の cache pull がすべて Artifact Registry から
+# インターネットへ出る転送になっていた。build から smoke test・years-export までを
+# 同じリージョンの Cloud Build に寄せることで、レイヤ転送を asia-northeast1 内に
+# 閉じ込める (同一ロケーション内の転送は無料)。
+#
+# Cloud Run への deploy はここでは行わない。GitHub Actions 側の Workload Identity
+# Federation が持つ境界 (master かつ deploy.yml からのみ認証できる) を維持するため、
+# builder サービスアカウントには Cloud Run の権限を一切与えない。
+#
+# ステップは上から順に実行され、失敗した時点で以降は走らない。したがって
+# 「runtime 完成 → smoke test 成功 → ビルド成功」の順序は構造的に保証される。
+
+# ビルド本体の上限。GitHub Actions のジョブ timeout より内側に置き、Cloud Build 自身が
+# TIMEOUT として記録する形にする (GHA が先に待ち受けを殺すとビルドだけが走り続ける)。
+# この timeout に queue 待ちは含まれないので、GHA 側はさらに余裕を持たせている
+timeout: 3600s
+
+options:
+  # 無料枠 (billing account あたり月 2,500 build-minutes) の対象は default pool の
+  # e2-standard-2 に限られる。現状の既定値と同じだが、既定が変わっても枠から
+  # 外れないよう明示的に固定する
+  machineType: E2_STANDARD_2
+  # user-specified service account を使うビルドは Google 所有のログバケットを使えない。
+  # Cloud Logging に寄せることで、自プロジェクトに GCS のログバケットを作らずに済む
+  # (この設定時 defaultLogsBucketBehavior は無視される)。
+  # 代償としてビルドログの live streaming ができないため、deploy.yml は完了後に
+  # gcloud builds log でまとめて取得する
+  logging: CLOUD_LOGGING_ONLY
+
+# イメージ参照 (asia-northeast1-docker.pkg.dev/$PROJECT_ID/perldoc-jp/app) は
+# 複数ステップの env: に現れる。リージョンやリポジトリ名を変えるときは、
+# deploy.yml の IMAGE と docs/cloud-run.md §2 も合わせて書き換えること。
+#
+# substitutions: は宣言しない。既定の MUST_MATCH により、未定義の substitution を
+# 参照した時点でビルドが始まる前に失敗する。空文字を渡された場合は弾けないので
+# setup-tools で値そのものを検証する。
+#
+# project ID は §7 の分類で secret として扱っているため、このファイルには書かず
+# built-in の $PROJECT_ID から組み立てる。git_source では $COMMIT_SHA /
+# $BRANCH_NAME が埋まる保証がないので使わない。
+
+steps:
+  # docker CLI と buildx プラグインを named volume に取り出す。
+  # 以降の docker を使うステップは gcr.io/cloud-builders/gcloud を image にしていて
+  # (Artifact Registry の credential helper がそこにしかない)、docker が入っていない。
+  #
+  # この image は Alpine (musl) だが、取り出す 2 つのバイナリはどちらも静的リンク
+  # なので glibc の image でもそのまま動く。docker-library/docker の Dockerfile は
+  # CLI を download.docker.com の static リリース tarball から、buildx を
+  # docker/buildx の GitHub Release から入れており、どちらの ELF にも PT_INTERP が
+  # 無いことを確認済み。バージョンを上げるときはここも確認すること
+  # (smoke-test は Debian ベースの perl image でこの docker を使うため、
+  #  ここが崩れると push まで終わった後に落ちる)
+  - id: setup-tools
+    name: 'docker:29.7.2-cli@sha256:3f4743208d2338c934d7b8bcfbe1bb54c0b2355c510ad5e0f31c0c4a54bd704e'
+    entrypoint: 'sh'
+    volumes:
+      - name: 'ci'
+        path: '/ci'
+    # substitution の値は shell のソース本文に埋め込まず、環境変数として渡す。
+    # 外部 (git ls-remote の結果) 由来の値が構文として再解釈されないようにする
+    env:
+      - 'TAG=${_TAG}'
+      - 'TRANSLATION_COMMIT=${_TRANSLATION_COMMIT}'
+    args:
+      - -ceu
+      - |
+        # busybox sh には bash の =~ が無いので case と長さで確かめる。
+        # grep だと値に改行が紛れたときに行単位で一致してしまう
+        test -n "$$TAG"
+        test "$${#TRANSLATION_COMMIT}" -eq 40
+        case "$$TRANSLATION_COMMIT" in
+          *[!0-9a-f]*) echo 'TRANSLATION_COMMIT が 40 桁の hex ではない' >&2; exit 1 ;;
+        esac
+
+        mkdir -p /ci/bin /ci/docker/cli-plugins /ci/no-credentials
+        install -m 0755 /usr/local/bin/docker /ci/bin/docker
+        # docker CLI は $$DOCKER_CONFIG/cli-plugins をプラグインの探索先に含む
+        install -m 0755 /usr/local/libexec/docker/cli-plugins/docker-buildx \
+          /ci/docker/cli-plugins/docker-buildx
+
+  # Artifact Registry への認証は credential helper に任せる。
+  # ビルド開始時に取得した 1 個のアクセストークンを全ステップで使い回すと、ビルドが
+  # 長引いたときに最後の push / cache export だけが失効と競り合う。helper は
+  # その時点の active service account の short-lived credentials を返すので、
+  # 少なくとも docker / buildx の起動ごとに取り直される。
+  # ただし buildx は 1 回の build 呼び出しの中では取得した資格情報をキャッシュする
+  # ため、build-runtime のような単一の長時間ステップの中まで更新されるとは限らない。
+  # timeout に迫るビルドで最後の --push / --cache-to が通ることは、cutover 時に
+  # 実地で確かめる (docs/cloud-run.md §11-3)
+  - id: configure-docker
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    volumes:
+      - name: 'ci'
+        path: '/ci'
+    env:
+      - 'DOCKER_CONFIG=/ci/docker'
+      - 'REGISTRY=asia-northeast1-docker.pkg.dev'
+    args:
+      - -ceu
+      - |
+        export PATH=/ci/bin:$$PATH
+        gcloud auth configure-docker "$$REGISTRY" --quiet
+
+        # registry cache を mode=max で書くには docker-container ドライバが要る
+        # (既定の docker ドライバは cache-to type=registry に対応しない)。
+        # buildkit の image は可動タグ (buildx-stable-1) を使わず digest で固定する
+        docker buildx create --name perldocjp \
+          --driver docker-container \
+          --driver-opt image=moby/buildkit:v0.32.2@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8 \
+          --bootstrap
+        docker buildx inspect perldocjp
+
+  # runtime を作って Artifact Registry へ push する。
+  # test ステージの /tests-passed への COPY があるため、prove を通らずに
+  # runtime が完成することは構造的にない (Dockerfile 参照)
+  - id: build-runtime
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    volumes:
+      - name: 'ci'
+        path: '/ci'
+    env:
+      - 'DOCKER_CONFIG=/ci/docker'
+      - 'IMAGE=asia-northeast1-docker.pkg.dev/$PROJECT_ID/perldoc-jp/app'
+      - 'TAG=${_TAG}'
+      - 'TRANSLATION_COMMIT=${_TRANSLATION_COMMIT}'
+    args:
+      - -ceu
+      - |
+        export PATH=/ci/bin:$$PATH
+        # --platform: Cloud Run は linux/amd64 のみ。従来はランナーのアーキテクチャに
+        #   暗黙に依存していたので、設定として固定する
+        # --provenance=mode=max: 従来 docker/build-push-action が public リポジトリの
+        #   push で既定的に付けていた attestation の粒度に揃える (素の buildx の
+        #   既定は mode=min)。manifest の形は変わらないが、attestation 内の
+        #   builder-id は action が入れていた GitHub Actions の run URL ではなく
+        #   Cloud Build 側の値になる。Cloud Run 側の要件ではない
+        docker buildx build --builder perldocjp \
+          --target runtime \
+          --platform linux/amd64 \
+          --build-arg "TRANSLATION_COMMIT=$$TRANSLATION_COMMIT" \
+          --cache-from "type=registry,ref=$$IMAGE:buildcache" \
+          --cache-to "type=registry,ref=$$IMAGE:buildcache,mode=max" \
+          --provenance=mode=max \
+          --tag "$$IMAGE:$$TAG" \
+          --push \
+          .
+
+  # smoke test は「Artifact Registry が実際に保持しているもの」を検査対象にする
+  # (レジストリへの往復も検証範囲に含める)。buildx の docker-container ドライバは
+  # --push してもローカルの daemon には load しないため、明示的に pull する
+  - id: pull-runtime
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    volumes:
+      - name: 'ci'
+        path: '/ci'
+    env:
+      - 'DOCKER_CONFIG=/ci/docker'
+      - 'IMAGE=asia-northeast1-docker.pkg.dev/$PROJECT_ID/perldoc-jp/app'
+      - 'TAG=${_TAG}'
+    args:
+      - -ceu
+      - |
+        export PATH=/ci/bin:$$PATH
+        docker pull "$$IMAGE:$$TAG"
+
+  # 本番同等の構成 (PLACK_ENV=deployment・immutable DSN・slim イメージ) は
+  # databuild の prove (PLACK_ENV=build) では検証されないため、Cloud Run 相当の
+  # FS 制約で起動して開通確認する。使うスクリプトは PR の test.yml と同じもの。
+  #
+  # image は Dockerfile の base ステージと同じ perl:5.42-trixie を使う
+  # (新しい供給元を増やさない)。DOCKER_CONFIG は空のディレクトリを指し、
+  # このステップにはレジストリの資格情報を渡さない。pull-runtime が取り込んだ
+  # ローカルの image だけを検査する構造であることを明示し、取りこぼしがあれば
+  # 黙って再取得せず失敗させる
+  - id: smoke-test
+    name: 'perl:5.42-trixie'
+    entrypoint: 'sh'
+    volumes:
+      - name: 'ci'
+        path: '/ci'
+    env:
+      - 'DOCKER_CONFIG=/ci/no-credentials'
+      # ビルドステップ自身がコンテナなので、ホストの loopback へ publish しても
+      # 届かない。Cloud Build が各ステップを繋いでいる docker network に相乗りする
+      - 'SMOKE_DOCKER_NETWORK=cloudbuild'
+      - 'IMAGE=asia-northeast1-docker.pkg.dev/$PROJECT_ID/perldoc-jp/app'
+      - 'TAG=${_TAG}'
+    args:
+      - -ceu
+      - |
+        export PATH=/ci/bin:$$PATH
+        exec ./script/smoke-test.pl "$$IMAGE:$$TAG"
+
+  # ビルドで再導出された data/years.pl を取り出す。deploy.yml の commit-years-data が
+  # master へ書き戻すために使う (databuild が git から再導出するのは前年+当年だけなので、
+  # 書き戻しが無いとある年の統計は 2 年後にシードのコミット時点の内容で凍結される)。
+  #
+  # 同じ builder のローカルキャッシュに全レイヤが載っているので実質即時に終わる。
+  # registry の cache-from は、builder のローカル状態 (GC 等) に関わらず databuild が
+  # 再実行されないようにするための保険。--platform を runtime と揃えないと
+  # 別のビルドグラフになりキャッシュに当たらない
+  - id: years-export
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    volumes:
+      - name: 'ci'
+        path: '/ci'
+    env:
+      - 'DOCKER_CONFIG=/ci/docker'
+      - 'IMAGE=asia-northeast1-docker.pkg.dev/$PROJECT_ID/perldoc-jp/app'
+      - 'TRANSLATION_COMMIT=${_TRANSLATION_COMMIT}'
+    args:
+      - -ceu
+      - |
+        export PATH=/ci/bin:$$PATH
+        docker buildx build --builder perldocjp \
+          --target years-export \
+          --platform linux/amd64 \
+          --build-arg "TRANSLATION_COMMIT=$$TRANSLATION_COMMIT" \
+          --cache-from "type=registry,ref=$$IMAGE:buildcache" \
+          --output "type=local,dest=/ci/years-out" \
+          .
+
+  # GitHub Actions へ渡すのは 1 MB 未満のこのファイルだけ。オブジェクト名は
+  # deploy.yml が組み立てた run ごとに一意な TAG で、GitHub 側が取得後に削除する
+  # (取りこぼしはバケットの lifecycle が 1 日で回収する)
+  - id: upload-years
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    volumes:
+      - name: 'ci'
+        path: '/ci'
+    env:
+      - 'OBJECT=gs://$PROJECT_ID-build-artifacts/years/${_TAG}.pl'
+    args:
+      - -ceu
+      - |
+        test -s /ci/years-out/years.pl
+        gcloud storage cp /ci/years-out/years.pl "$$OBJECT"

--- a/docs/cloud-run.md
+++ b/docs/cloud-run.md
@@ -10,9 +10,17 @@ perldoc.jp を Google Cloud Run で動かすための構成と、初期セット
 [schedule: 日次保険]  ───────────────────────────────────┤
                                                          v
                 GitHub Actions (.github/workflows/deploy.yml)
+                  WIF 認証 → translation の HEAD 解決
+                  → Cloud Build を github.sha 固定で submit
+                                                         v
+                Cloud Build (asia-northeast1 / cloudbuild.yaml)
                   translation取得 → SQLite構築 → データ生成
                   → テスト → Docker build → Artifact Registry push
-                  → Cloud Run deploy
+                  → smoke test → years-export
+                                                         v
+                GitHub Actions (.github/workflows/deploy.yml)
+                  years.pl を取得 → Cloud Run deploy
+                  → commit-years-data が data/years.pl を master へ
                                                          v
 [ユーザー] → Cloudflare (Worker) → Cloud Run (asia-northeast1)
                            - min-instances=0 (無アクセス時のコストほぼゼロ)
@@ -21,6 +29,15 @@ perldoc.jp を Google Cloud Run で動かすための構成と、初期セット
                              (Xslate キャッシュと diff 用の一時ファイル)
 ```
 
+- **イメージのビルドは Cloud Build (asia-northeast1) で行う** (§11)。GitHub-hosted
+  runner でビルドしていた頃は、buildcache の pull・smoke test のための image pull・
+  years-export の cache pull がいずれも Artifact Registry からインターネットへ出る
+  data transfer out になっていた。同一ロケーション内の転送は無料なので、数百 MB〜GB
+  級のレイヤ転送を asia-northeast1 の中に閉じ込める。
+  `script/smoke-test.pl` は手元に無いイメージを `docker run` の自動 pull で取りに行く
+  ため、ビルドだけを移して smoke test を GitHub Actions に残す分割では転送は消えない。
+  Cloud Run への deploy は GitHub Actions 側に残す (WIF の境界を維持し、Cloud Build の
+  サービスアカウントに Cloud Run の権限を持たせないため)。
 - データ更新は「イメージ再ビルド + 再デプロイ」に一本化されている。VPS 時代の
   cron (10分毎の script/update.pl) に相当する処理は Dockerfile の databuild
   ステージが担う。
@@ -89,11 +106,17 @@ gcloud billing projects link "$PROJECT_ID" \
 
 gcloud services enable --project="$PROJECT_ID" \
   run.googleapis.com artifactregistry.googleapis.com \
+  cloudbuild.googleapis.com storage.googleapis.com \
   iam.googleapis.com iamcredentials.googleapis.com sts.googleapis.com
 ```
 
+`cloudbuild.googleapis.com` は §11 のイメージビルド、`storage.googleapis.com` は
+§11 の years.pl 受け渡し用バケットが使う。
+
 `compute.googleapis.com` は有効化しない。Cloud Run のランタイムには専用のサービス
-アカウントを作る (§3) ため、Compute Engine のデフォルト SA を使わない。
+アカウントを作る (§3) ため、Compute Engine のデフォルト SA を使わない。Cloud Build も
+default pool (Google 管理側の VM) しか使わないので不要なはずだが、これは公式ドキュメントに
+明記が無いため §11-2 の preflight で「有効化を要求されないこと」を確かめる。
 
 ### 2. Artifact Registry
 
@@ -199,6 +222,9 @@ GitHub Actions からキーレスで認証するための設定。権限はプ�
 リソース (Cloud Run サービス / Artifact Registry リポジトリ / サービスアカウント) に
 付与する。
 
+イメージをビルドする Cloud Build 側は別のサービスアカウントを使う。作成と、この
+デプロイ用 SA に足す分のバインディングは §11 にまとめてある。
+
 ```sh
 gcloud iam service-accounts create perldoc-jp-deployer \
   --project="$PROJECT_ID" \
@@ -214,7 +240,12 @@ gcloud run services add-iam-policy-binding perldoc-jp \
   --project="$PROJECT_ID" --region="$REGION" \
   --member="serviceAccount:$SA" --role=roles/run.developer
 
-# イメージの push と buildcache の読み書き
+# イメージの push と buildcache の読み書き。
+# 本番ビルドを Cloud Build へ移した後 (§11) は、この SA が push することは
+# なくなるので roles/artifactregistry.reader へ降格する。ただし削除はしない:
+# gcloud run deploy はデプロイ主体にも
+# artifactregistry.repositories.downloadArtifacts を要求する。
+# 降格は cutover が成功してから行う (§11-3)
 gcloud artifacts repositories add-iam-policy-binding perldoc-jp \
   --project="$PROJECT_ID" --location="$REGION" \
   --member="serviceAccount:$SA" --role=roles/artifactregistry.writer
@@ -323,6 +354,13 @@ WIF provider (`projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/
 と SA email (`perldoc-jp-deployer@<PROJECT_ID>.iam.gserviceaccount.com`) は
 deploy.yml が上記 2 つの secret から組み立てるため、個別には保存しない
 (project number / ID の重複保存を避ける)。
+
+同じ理由で、Cloud Build 移行 (§11) でも **secret も variable も増やしていない**。
+builder SA email (`perldoc-jp-builder@<PROJECT_ID>.iam.gserviceaccount.com`) と
+years 成果物バケット名 (`<PROJECT_ID>-build-artifacts`) は deploy.yml が
+`GCP_PROJECT_ID` から組み立て、`cloudbuild.yaml` 側は built-in の `$PROJECT_ID`
+substitution を使う (リポジトリのファイルに project ID を書かない)。
+Cloud Build が fetch するソースの URL は公開リポジトリのものなので機密ではない。
 
 environment は workflow から参照されただけでも自動作成されるが、その場合は
 branch policy の無い素通しになり、environment に secret が無ければ同名の
@@ -445,7 +483,12 @@ push が成功することを確認すること。
 ### 8. 手動でのビルドとデプロイ
 
 master へ merge する前の cutover はこの手順で行う。使うのは操作者自身の gcloud
-認証情報で、デプロイ用 SA (§5) は経由しない。
+認証情報で、デプロイ用 SA (§5) は経由しない。本番ビルドが Cloud Build (§11) へ
+移った後もこの手順はそのまま使える (操作者の権限で手元からビルドするため、
+デプロイ用 SA の権限を絞っても影響を受けない)。
+
+Cloud Build 側の経路を手で回したい場合は、§11 の submit コマンドを
+`--git-source-revision` に確かめたい commit SHA を渡して実行する。
 
 事前に `data/years.pl` が過去年 (2002〜) を含む現物になっていることを確認する。
 `.dockerignore` に含まれないため作業ツリーの内容がそのままイメージに焼き込まれ、
@@ -480,8 +523,13 @@ docker buildx build \
   フルビルドになる。
 - push したイメージを Cloud Run が受け付けない場合は `--provenance=false` を足す
   (buildx が既定で付ける attestation により manifest が image index になるため)。
+- CI が作るイメージに揃えたい場合は `--provenance=mode=max` を足す。
+  `cloudbuild.yaml` がこれを明示しているのは、以前 GitHub Actions で使っていた
+  `docker/build-push-action` が public リポジトリの push に対して既定で
+  `--attest type=provenance,mode=max` を付けており (素の buildx の既定は
+  `mode=min`)、成果物の形を変えないため。Cloud Run 側の要件ではない。
 
-本番同等の FS 制約で起動確認してからデプロイする (deploy.yml / test.yml の
+本番同等の FS 制約で起動確認してからデプロイする (cloudbuild.yaml / test.yml の
 smoke test と同じスクリプト)。ホスト側では Perl 5.38 以降を使用し、追加の
 CPAN モジュールは必要ない:
 
@@ -887,7 +935,7 @@ cutover 後と同じ経路で挙動を確かめられる。`workers.dev` のサ�
    ```sh
    BASE=https://staging.perldoc.jp
 
-   # アプリの主要な経路 (deploy.yml の smoke test と同じ観点)
+   # アプリの主要な経路 (script/smoke-test.pl と同じ観点)
    curl -fsS "$BASE/" | grep 'perldoc.jp' > /dev/null
    curl -fsS -o /dev/null "$BASE/docs/perl/perl.pod"
    curl -fsS "$BASE/translators" | grep '年</h2>' > /dev/null
@@ -1074,6 +1122,375 @@ Worker を挟まない構成にする場合の選択肢:
   (Cloudflare Origin CA) が使えて Google が推奨する構成でもあるが、転送ルールだけで
   概算 月 $18〜25 かかり、min-instances=0 のコスト方針とは釣り合わない
 
+### 11. Cloud Build (本番イメージのビルド)
+
+`.github/workflows/deploy.yml` は、ビルド・テスト・smoke test・years-export を
+Cloud Build (`cloudbuild.yaml`) に投げる。GitHub-hosted runner が Artifact Registry から
+buildcache や runtime イメージを引くと、そのたびにインターネットへの data transfer out に
+なるため、大きいレイヤ転送を asia-northeast1 の中で完結させる。
+
+ソースは 2nd-gen の GitHub connection を使わず、**公開リポジトリの exact commit SHA を
+Cloud Build 自身に fetch させる** (`gcloud builds submit <URL> --git-source-revision <SHA>`)。
+`--config` に渡す `cloudbuild.yaml` だけは gcloud が手元から読んで Build を組み立てる
+(ビルドの定義は呼び出し側、ビルドコンテキストは Cloud Build が fetch したもの)。
+deploy.yml は `actions/checkout` した作業ツリーから渡すので、どちらも同じ
+`github.sha` になる。
+connection 方式は Cloud Build GitHub App のインストールと、Secret Manager 上に置かれる
+GitHub ユーザーの OAuth トークンを常設で必要とする。このリポジトリは公開なので、
+そのどれも持たずに済ませる。ローカルの checkout を送る `gcloud builds submit .` も使わない
+(ソースが `gs://<PROJECT_ID>_cloudbuild` に溜まるため)。
+
+§2 (Artifact Registry) と §5 (デプロイ用 SA) の後に、**この順で**実行する。
+
+#### 11-1. builder サービスアカウントと成果物バケット
+
+preflight (11-2) は builder SA を指定して回すので、SA と最低限の IAM が先に要る。
+
+```sh
+gcloud iam service-accounts create perldoc-jp-builder \
+  --project="$PROJECT_ID" --display-name='perldoc.jp Cloud Build builder'
+
+BUILDER_SA=perldoc-jp-builder@${PROJECT_ID}.iam.gserviceaccount.com
+
+# イメージの push と buildcache の読み書き
+gcloud artifacts repositories add-iam-policy-binding perldoc-jp \
+  --project="$PROJECT_ID" --location="$REGION" \
+  --member="serviceAccount:$BUILDER_SA" --role=roles/artifactregistry.writer
+
+# ビルドログの書き込み (cloudbuild.yaml は logging: CLOUD_LOGGING_ONLY)
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:$BUILDER_SA" --role=roles/logging.logWriter
+```
+
+builder SA には **Cloud Run の権限を一切与えない**。デプロイは GitHub Actions 側に
+残してあり (§5 の WIF が持つ「master かつ deploy.yml からのみ」という境界を維持するため)、
+ビルド側にその境界を跨がせない。
+
+`data/years.pl` を GitHub Actions へ戻すための小さなバケットを作る。ソースの staging には
+使わない (そもそも staging bucket を作らせない構成にしてある)。
+
+```sh
+# soft delete は既定 7 日で、削除済みオブジェクトもその間は課金対象になる。
+# 1 ビルドで作って直後に消す用途なので 0 にする
+gcloud storage buckets create "gs://${PROJECT_ID}-build-artifacts" \
+  --project="$PROJECT_ID" --location="$REGION" \
+  --uniform-bucket-level-access --public-access-prevention \
+  --soft-delete-duration=0
+
+# GitHub Actions 側の削除が落ちた場合の保険。1 日で自動削除する
+# (lifecycle による削除は無料オペレーション)
+cat > /tmp/years-lifecycle.json <<'EOF'
+{"rule":[{"action":{"type":"Delete"},"condition":{"age":1}}]}
+EOF
+gcloud storage buckets update "gs://${PROJECT_ID}-build-artifacts" \
+  --lifecycle-file=/tmp/years-lifecycle.json
+
+# アップロードだけできればよい (読み出しと削除は GitHub Actions 側の SA が行う)
+gcloud storage buckets add-iam-policy-binding "gs://${PROJECT_ID}-build-artifacts" \
+  --member="serviceAccount:$BUILDER_SA" --role=roles/storage.objectCreator
+```
+
+#### 11-2. preflight (cutover の必須前提)
+
+`cloudbuild.yaml` は、Cloud Build のビルドステップ実行環境について公式ドキュメントに
+明記が無いことをいくつか前提にしている。**production の Cloud Build で 1 回検証してから**
+cutover すること。ローカルエミュレータ (`cloud-build-local`) の実装や第三者の報告を
+根拠にしない。
+
+公式ドキュメントで確認できている (preflight の対象外):
+
+- Cloud Build は各ステップのコンテナを `cloudbuild` という docker network に接続する
+- ステップの image に Google 提供でない public / custom image を使える
+
+preflight で確かめるのは次の 8 点:
+
+1. ステップから `/var/run/docker.sock` が使える
+2. named volume がステップ間で共有される
+3. `gcr.io/cloud-builders/gcloud` の PATH 上に `docker-credential-gcloud` がある
+   (Cloud SDK には同梱されており、`gcloud auth configure-docker` が `DOCKER_CONFIG`
+   を尊重することも SDK のコードで確認済み。未確認なのはこの image の PATH だけ)
+4. その credential helper 経由で Artifact Registry に push / pull できる
+5. `docker buildx create --driver docker-container --bootstrap` が起動する
+   (= ステップが `--privileged` 相当で動く)
+6. `--network cloudbuild --network-alias` で起動した隣のコンテナに、別のステップから
+   network alias で HTTP 到達できる (`script/smoke-test.pl` が通る経路)
+7. Alpine (musl) の `docker:<VERSION>-cli` から取り出した docker CLI が、glibc の
+   `perl:5.42-trixie` でも実行でき、そこから docker socket を使える
+   (smoke test のステップがまさにこの組み合わせ。ここが崩れると、ビルドと push が
+   終わった後の一番高くつく地点で落ちる)
+8. builder SA の `roles/storage.objectCreator` だけで `gcloud storage cp` が通る
+   (production では years.pl のアップロードが最後のステップなので、権限不足だと
+   ビルド全体を捨てることになる)
+
+`docker:<VERSION>-cli` への buildx プラグインの同梱と、取り出す 2 つのバイナリが
+静的リンクであることは、image の config と ELF ヘッダで確認済みなので未確認項目には
+数えない。ただし `cloudbuild.yaml` と preflight のどちらにも `test -x` のガードを
+残してあるので、バージョンを上げて構成が変わればそこで落ちる (落ちた場合は
+`docker/buildx-bin:<VERSION>` から取る形に変える)。
+
+```sh
+cat > /tmp/cloudbuild-preflight.yaml <<'EOF'
+timeout: 900s
+options:
+  machineType: E2_STANDARD_2
+  logging: CLOUD_LOGGING_ONLY
+steps:
+  - id: tools
+    name: 'docker:29.7.2-cli@sha256:3f4743208d2338c934d7b8bcfbe1bb54c0b2355c510ad5e0f31c0c4a54bd704e'
+    entrypoint: 'sh'
+    volumes:
+      - name: 'ci'
+        path: '/ci'
+    args:
+      - -ceu
+      - |
+        test -S /var/run/docker.sock                                   # (1)
+        test -x /usr/local/libexec/docker/cli-plugins/docker-buildx    # buildx 同梱
+        mkdir -p /ci/bin /ci/docker/cli-plugins
+        install -m 0755 /usr/local/bin/docker /ci/bin/docker
+        install -m 0755 /usr/local/libexec/docker/cli-plugins/docker-buildx \
+          /ci/docker/cli-plugins/docker-buildx
+        docker version
+
+  - id: buildx
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    volumes:
+      - name: 'ci'
+        path: '/ci'
+    env:
+      - 'DOCKER_CONFIG=/ci/docker'
+      - 'REGISTRY=asia-northeast1-docker.pkg.dev'
+    args:
+      - -ceu
+      - |
+        export PATH=/ci/bin:$$PATH
+        test -x /ci/bin/docker                                         # (2)
+        command -v docker-credential-gcloud                            # (3)
+        gcloud auth configure-docker "$$REGISTRY" --quiet
+        grep -q "$$REGISTRY" /ci/docker/config.json                    # (3)
+        docker buildx create --name preflight --driver docker-container \
+          --driver-opt image=moby/buildkit:v0.32.2@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8 \
+          --bootstrap                                                  # (5)
+        docker buildx inspect preflight
+
+  - id: registry
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    volumes:
+      - name: 'ci'
+        path: '/ci'
+    env:
+      - 'DOCKER_CONFIG=/ci/docker'
+      - 'IMAGE=asia-northeast1-docker.pkg.dev/$PROJECT_ID/perldoc-jp/app:preflight-$BUILD_ID'
+    args:
+      - -ceu
+      - |
+        export PATH=/ci/bin:$$PATH
+        mkdir -p /ci/preflight
+        # 新しい供給元を増やさないよう、上でピン留めした image をそのまま土台にする
+        cat > /ci/preflight/Dockerfile <<'DOCKERFILE'
+        FROM docker:29.7.2-cli@sha256:3f4743208d2338c934d7b8bcfbe1bb54c0b2355c510ad5e0f31c0c4a54bd704e
+        RUN mkdir -p /srv && printf 'preflight-ok' > /srv/index.html
+        # docker:cli の ENTRYPOINT (docker-entrypoint.sh) を通さず直接起動する
+        ENTRYPOINT []
+        CMD ["busybox","httpd","-f","-p","8080","-h","/srv"]
+        DOCKERFILE
+        docker buildx build --builder preflight --platform linux/amd64 \
+          --tag "$$IMAGE" --push /ci/preflight                         # (4) push
+        docker pull "$$IMAGE"                                          # (4) pull
+        docker run -d --name preflight-app --network cloudbuild \
+          --network-alias preflight-app "$$IMAGE"
+
+  # smoke test と同じ image・同じ手段で検証する。
+  # まず Alpine から持ってきた docker CLI が glibc の image で動き、socket を
+  # 使えること (7)、次に隣のコンテナへ HTTP::Tiny で届くこと (6)
+  - id: reachability
+    name: 'perl:5.42-trixie'
+    entrypoint: 'sh'
+    volumes:
+      - name: 'ci'
+        path: '/ci'
+    args:
+      - -ceu
+      - |
+        /ci/bin/docker --version                                       # (7) 実行できるか
+        /ci/bin/docker ps > /dev/null                                  # (7) socket を使えるか
+        cat > /ci/reachability.pl <<'REACH'
+        use HTTP::Tiny;
+        my $$r;
+        for (1 .. 15) {
+          $$r = HTTP::Tiny->new(timeout => 5, proxy => undef, http_proxy => undef)
+            ->get('http://preflight-app:8080/');
+          last if $$r->{success};
+          sleep 2;
+        }
+        die "unreachable: $$r->{status} $$r->{reason}\n" unless $$r->{success};
+        die "unexpected body: $$r->{content}\n" unless $$r->{content} eq 'preflight-ok';
+        print "reachability OK\n";
+        REACH
+        exec perl /ci/reachability.pl                                  # (6)
+
+  # production の最後のステップと同じ経路で、builder SA の
+  # roles/storage.objectCreator だけで書けることを確かめる。
+  # 置いたオブジェクトはバケットの lifecycle (age 1) が翌日に回収する
+  - id: years-upload
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    volumes:
+      - name: 'ci'
+        path: '/ci'
+    env:
+      - 'OBJECT=gs://$PROJECT_ID-build-artifacts/preflight/$BUILD_ID.txt'
+    args:
+      - -ceu
+      - |
+        printf 'preflight' > /ci/years-probe.txt
+        gcloud storage cp /ci/years-probe.txt "$$OBJECT"               # (8)
+
+  - id: cleanup
+    name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    volumes:
+      - name: 'ci'
+        path: '/ci'
+    args:
+      - -ceu
+      - |
+        export PATH=/ci/bin:$$PATH
+        docker rm -f preflight-app || true
+EOF
+
+gcloud builds submit --no-source \
+  --project="$PROJECT_ID" \
+  --region="$REGION" \
+  --config=/tmp/cloudbuild-preflight.yaml \
+  --service-account="projects/${PROJECT_ID}/serviceAccounts/${BUILDER_SA}"
+```
+
+実行するのは操作者自身の資格情報 (デプロイ用 SA はまだ使わない)。
+`--service-account` を指定するので、操作者に builder SA への `iam.serviceAccounts.actAs`
+が要る (Owner なら暗黙に持つ)。
+
+preflight が push した `:preflight-<BUILD_ID>` タグは、操作者の資格情報で消しておく
+(builder SA には削除権限を与えていない。放置しても §2 の cleanup policy が 30 日で回収する):
+
+```sh
+gcloud artifacts docker images delete \
+  "${REGION}-docker.pkg.dev/${PROJECT_ID}/perldoc-jp/app:preflight-<BUILD_ID>" \
+  --project="$PROJECT_ID" --delete-tags --quiet
+```
+
+いずれかの assertion が崩れた場合は、`cloudbuild.yaml` の該当ステップを
+`gcr.io/cloud-builders/*` に寄せる、`docker run` の入れ子にする等の代替へ切り替えてから
+cutover する。**preflight が全部通るまで cutover しない。**
+
+#### 11-3. デプロイ用 SA への追加バインディングと cutover
+
+preflight が通ってから、§5 のデプロイ用 SA に Cloud Build を submit する権限を足す。
+
+```sh
+SA=perldoc-jp-deployer@${PROJECT_ID}.iam.gserviceaccount.com
+
+# ビルドの submit / get / list / cancel
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:$SA" --role=roles/cloudbuild.builds.editor
+
+# gcloud builds submit が要求する serviceusage.services.use。
+# ただし gcloud がこれを要求するのは source を Cloud Storage へ staging する経路で、
+# git URL を source にする本構成ではその分岐に入らない可能性がある。
+# プロジェクト全体のロールなので、cutover が安定したら一度外して submit が通るか
+# 確かめ、通るなら外す (Artifact Registry の降格と同じ進め方)
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:$SA" --role=roles/serviceusage.serviceUsageConsumer
+
+# --service-account で builder SA を指定するのに要る iam.serviceAccounts.actAs
+gcloud iam service-accounts add-iam-policy-binding "$BUILDER_SA" \
+  --project="$PROJECT_ID" \
+  --member="serviceAccount:$SA" --role=roles/iam.serviceAccountUser
+
+# years.pl の取得と、取得後の削除
+gcloud storage buckets add-iam-policy-binding "gs://${PROJECT_ID}-build-artifacts" \
+  --member="serviceAccount:$SA" --role=roles/storage.objectUser
+```
+
+任意: ビルドログを GitHub Actions のログに出したい場合。`cloudbuild.yaml` は
+`logging: CLOUD_LOGGING_ONLY` なので、`gcloud builds log` は Cloud Logging を読む。
+付与しなくても workflow は動く (ログ取得に失敗しても握りつぶし、Cloud Console の URL を
+案内する)。プロジェクト全体のログ閲覧権限になるので、要否は判断すること。
+
+```sh
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:$SA" --role=roles/logging.viewer
+```
+
+ここまでで cutover し、Deploy workflow が 1 回成功することを確認する。
+
+**cutover 時に必ず見ること:**
+
+- `timeout: 3600s` に迫る長さのビルドでも、最後の `--push` と `--cache-to` が
+  認証エラーにならないこと。credential helper は docker / buildx の起動ごとに
+  呼ばれるが、buildx は 1 回の build 呼び出しの中では資格情報をキャッシュするため、
+  単一の長時間ステップの内部まで更新される保証はない。問題になるようなら
+  `build-runtime` を分割するか、machine type を上げてビルド時間を短くする
+- 実ビルド時間を測り、`cloudbuild.yaml` の `timeout` と deploy.yml の
+  `timeout-minutes` を実測に合わせて詰めること (「運用」の `gcloud builds list`)
+- 無料枠 2,500 build-minutes に対する消費ペース
+
+**post-cutover: Artifact Registry の権限を降格する。** cutover と同時に行わないこと
+(`gcloud run deploy` が失敗したとき、Cloud Build 側の配線の問題か IAM の絞りすぎかを
+切り分けられなくなる)。降格後にもう 1 回デプロイが成功することまで確認する。
+
+```sh
+gcloud artifacts repositories remove-iam-policy-binding perldoc-jp \
+  --project="$PROJECT_ID" --location="$REGION" \
+  --member="serviceAccount:$SA" --role=roles/artifactregistry.writer
+
+# reader は残す。gcloud run deploy はデプロイ主体にも
+# artifactregistry.repositories.downloadArtifacts を要求する
+gcloud artifacts repositories add-iam-policy-binding perldoc-jp \
+  --project="$PROJECT_ID" --location="$REGION" \
+  --member="serviceAccount:$SA" --role=roles/artifactregistry.reader
+```
+
+#### 11-4. 一度きりの操作のまとめ
+
+リポジトリのコードだけでは完結しない操作を、実行順に並べたもの:
+
+1. §1 の API 有効化 (`cloudbuild.googleapis.com` / `storage.googleapis.com` を含む)
+2. builder SA の作成と IAM (11-1)
+3. years 成果物バケットの作成・lifecycle・IAM (11-1)
+4. preflight ビルド (11-2)
+5. デプロイ用 SA への追加バインディング (11-3)
+6. cutover
+7. デプロイ用 SA の Artifact Registry 権限を writer → reader へ降格 (11-3)
+
+**GitHub 側の追加操作は無い。secret も variable も増えない** (§7)。
+Cloud Build の 2nd-gen connection、Cloud Build GitHub App のインストール、
+Secret Manager はいずれも使わない。
+
+## この変更で課金対象になり得るもの
+
+イメージのビルドを Cloud Build へ移したことで増減するもの。金額は 2026-09 時点の
+公式 pricing を参照した値で、実際に請求される単価は最新のページで確認すること。
+
+| 項目 | 単価 | 見込み |
+|---|---|---|
+| Cloud Build build-minutes | **billing account あたり月 2,500 分が無料**。ただし脚注に "This promotional free tier is for e2-standard-2 machine types in the default pool" とあり、**promotional かつ default pool の `e2-standard-2` 限定**で、恒久ではない。超過分は $0.006/min。端数は実消費秒数で按分され、queue 待ちの時間は課金されない | 日次 schedule と translation 通知の頻度次第。無料枠に収まる想定だが、cutover 後に実測すること |
+| Artifact Registry storage | 0〜0.5 GiB-month が $0.00、以降 $0.10/GiB-month (billing account 単位) | 既存費用。§2 の cleanup policy のまま変わらない |
+| Artifact Registry ↔ Cloud Build (同一ロケーション) | **$0.00 (Free)**。"Data moves within the same location" に該当し、Cloud Build への data transfer in も無料 | **この変更の主目的**。buildcache の pull・イメージの push・smoke test のための pull がすべてここに入る |
+| Artifact Registry → インターネット (Premium Tier data transfer out) | 宛先別の階梯。North America 宛: 0〜1 GiB 無料 / 1〜1,024 GiB $0.12 / 1,024〜10,240 GiB $0.11 / 10,240 GiB 超 $0.08。Europe 宛と Asia 宛 (Korea・Indonesia を除く): 0〜1 GiB 無料 / $0.12 / $0.11 / $0.085。Australia・Indonesia・Korea・South America・Saudi Arabia 宛: $0.19 / $0.18 / $0.15。Middle East (Saudi Arabia を除く)・Africa 宛: 0〜1 GiB 無料 / $0.15 / $0.13 / $0.11。China 宛 (香港を除く): $0.23 / $0.22 / $0.20。data transfer in は無料 | **削減対象**。GitHub-hosted runner は Google のサービスではないので、runner が引くイメージ・キャッシュはここに入っていた。料金表は転送元リージョンで値が変わる (ページにセレクタがある) ため、`asia-northeast1` を選んだ実際の値で確認すること |
+| Cloud Logging | $0.50/GiB、**50 GiB/project/month が無料**。`_Default` バケットの既定保持期間 (30 日) には保持料金がかからない | `logging: CLOUD_LOGGING_ONLY` にしたビルドログの分。無料枠に収まる想定 |
+| Cloud Storage (years 成果物バケット) | asia-northeast1 の Standard は $0.000027397/GiB-hour (約 $0.020/GiB-month)。Class A $0.005/1,000 ops、Class B $0.0004/1,000 ops。**Always Free は US-WEST1 / US-CENTRAL1 / US-EAST1 のみで asia-northeast1 は対象外**。lifecycle と API による削除は無料オペレーション | `data/years.pl` は 1 MB 未満で、ビルドごとに書き込み 1 回・読み出し 1 回・削除 1 回。オブジェクトは取得直後に消え、取り逃しても 1 日で lifecycle が回収するので、保存容量はほぼ常にゼロ |
+| Artifact Analysis (脆弱性スキャン) | $0.26/scan。**Container Scanning API を有効化したときにだけ**課金が始まる。digest 単位で初回 push のみ課金され、タグの付け替えは無課金 | §1 で同 API を有効化していないため、**この変更で新たに発生する費用ではない**。有効化した場合も、push 元が GitHub Actions か Cloud Build かで差は出ない |
+
+避けている費用:
+
+- `gcloud builds submit .` を使わないので、ソースの staging bucket
+  (`gs://<PROJECT_ID>_cloudbuild`) は作られない。
+- `logging: CLOUD_LOGGING_ONLY` により `defaultLogsBucketBehavior` は無視され、
+  自プロジェクト内に GCS のログバケットは作られない。
+
 ## 旧 VPS の cron ジョブとの対応
 
 VPS で `PLACK_ENV=deployment` の crontab が回していたジョブと、移行後の担当:
@@ -1149,6 +1566,38 @@ workflow_dispatch (§9) で受けるため、翻訳がマージされてから�
   エッジキャッシュ (§10) の導入後、Cloud Run のリクエストログは
   ページビューではなく「エッジの MISS」に近い値になる。ページビューを
   見たい場合は Cloudflare 側の Analytics を使う
+- **本番イメージのビルド**: Cloud Build (asia-northeast1) が行う (§11)。ビルドログは
+  Cloud Logging に入り (`logging: CLOUD_LOGGING_ONLY`)、Deploy workflow が完了後に
+  `gcloud builds log` でまとめて GitHub Actions のログへ出す。この設定では live
+  streaming ができないので、進行中の様子を見たいときは Deploy workflow が submit
+  直後に表示する Cloud Console の URL を開く。
+  デプロイ用 SA に `roles/logging.viewer` を付けていない場合はログの取り出しに
+  失敗するが、その場合も workflow はビルドの成否だけで進退を決める (§11-3)
+- **ビルドを手で止める**:
+  `gcloud builds cancel <BUILD_ID> --project <PROJECT_ID> --region asia-northeast1`。
+  Deploy workflow 側がキャンセル・失敗した場合は workflow が自動で cancel する。
+  そのとき対象を引くのに使っているのは build ID ではなく run ごとに一意な
+  `_TAG` substitution で、`gcloud builds submit` が ID を返す前に中断されても
+  受理済みのビルドを回収できるようにしてある。手で探す場合も同じ引き方をする:
+  ```sh
+  gcloud builds list --project <PROJECT_ID> --region asia-northeast1 --ongoing \
+    --filter='substitutions._TAG=<GITHUB_SHA>-<RUN_ID>-<RUN_ATTEMPT>' \
+    --format='value(id)'
+  ```
+  進行中のものを全部見たいときは `--filter` を外す。放置すると、次の run のビルドと
+  同時に `:buildcache` を書きに行き、last-writer-wins で以後のキャッシュヒット率が落ちる
+- **Docker Hub の pull 回数**: ビルド 1 回につき、ステップの image
+  (`docker:<VERSION>-cli` / `moby/buildkit:<VERSION>` / `perl:5.42-trixie`) と
+  Dockerfile のベース (`perl:5.42-trixie` / `perl:5.42-slim-trixie`) を Docker Hub から
+  引く。Cloud Build の default pool は共有の egress IP から出るため、GitHub-hosted
+  runner だった頃より匿名 pull のレート制限に当たりやすい。当たった場合は
+  Artifact Registry の remote repository (Docker Hub のプロキシ) を作ってそちらを
+  参照するように `cloudbuild.yaml` と `Dockerfile` を書き換える
+- **無料枠の消費を見る**: Cloud Build の無料枠は billing account あたり月 2,500
+  build-minutes で、default pool の `e2-standard-2` にだけ適用される promotional な枠
+  (「この変更で課金対象になり得るもの」参照)。所要時間は
+  `gcloud builds list --project <PROJECT_ID> --region asia-northeast1 --limit 20 --format='table(id,status,createTime,startTime,finishTime)'`
+  で確認する
 - **data/years.pl の自動更新 (年次作業は不要)**: databuild は `create_data.pl`
   で前年+当年 (対象年は translation の最新イベントから導出) を毎ビルド
   translation の git 履歴から再導出し、デプロイ成功後に

--- a/docs/cloud-run.md
+++ b/docs/cloud-run.md
@@ -1208,8 +1208,8 @@ preflight で確かめるのは次の 7 点:
 4. その credential helper 経由で Artifact Registry に push / pull できる
 5. `docker buildx create --driver docker-container --bootstrap` が起動する
    (= ステップが `--privileged` 相当で動く)
-6. `--network cloudbuild --network-alias` で起動した隣のコンテナに、別のステップから
-   network alias で HTTP 到達できる (`script/smoke-test.pl` が通る経路)
+6. `--network cloudbuild` で起動した隣のコンテナへ、別のステップから network 上の
+   IP で HTTP 到達できる (`script/smoke-test.pl` が通る経路)
 7. Alpine (musl) の `docker:<VERSION>-cli` から取り出した docker CLI が、glibc の
    `perl:5.42-trixie` でも実行でき、そこから docker socket を使える
    (smoke test のステップがまさにこの組み合わせ。ここが崩れると、ビルドと push が
@@ -1281,19 +1281,30 @@ steps:
       - |
         export PATH=/ci/bin:$$PATH
         mkdir -p /ci/preflight
-        # 新しい供給元を増やさないよう、上でピン留めした image をそのまま土台にする
+        # 到達性の検査対象。busybox の applet 構成に賭けず、この preflight が
+        # すでに使っている perl イメージの上に最小の HTTP サーバを置く
+        # (Alpine の busybox には httpd applet が入っていない)
+        cat > /ci/preflight/server.pl <<'SERVER'
+        use IO::Socket::INET;
+        my $$sock = IO::Socket::INET->new(
+            LocalAddr => '0.0.0.0', LocalPort => 8080, Listen => 8, ReuseAddr => 1)
+            or die "listen: $$!\n";
+        while (my $$conn = $$sock->accept) {
+            my $$req = <$$conn>;
+            print {$$conn} "HTTP/1.0 200 OK\r\nContent-Length: 12\r\n\r\npreflight-ok";
+            close $$conn;
+        }
+        SERVER
         cat > /ci/preflight/Dockerfile <<'DOCKERFILE'
-        FROM docker:29.7.2-cli@sha256:3f4743208d2338c934d7b8bcfbe1bb54c0b2355c510ad5e0f31c0c4a54bd704e
-        RUN mkdir -p /srv && printf 'preflight-ok' > /srv/index.html
-        # docker:cli の ENTRYPOINT (docker-entrypoint.sh) を通さず直接起動する
+        FROM perl:5.42-trixie
+        COPY server.pl /server.pl
         ENTRYPOINT []
-        CMD ["busybox","httpd","-f","-p","8080","-h","/srv"]
+        CMD ["perl", "/server.pl"]
         DOCKERFILE
         docker buildx build --builder preflight --platform linux/amd64 \
           --tag "$$IMAGE" --push /ci/preflight                         # (4) push
         docker pull "$$IMAGE"                                          # (4) pull
-        docker run -d --name preflight-app --network cloudbuild \
-          --network-alias preflight-app "$$IMAGE"
+        docker run -d --name preflight-app --network cloudbuild "$$IMAGE"
 
   # smoke test と同じ image・同じ手段で検証する。
   # まず Alpine から持ってきた docker CLI が glibc の image で動き、socket を
@@ -1309,20 +1320,39 @@ steps:
       - |
         /ci/bin/docker --version                                       # (7) 実行できるか
         /ci/bin/docker ps > /dev/null                                  # (7) socket を使えるか
+
+        # 相手が死んでいると「到達できない」と区別が付かないので先に確かめる
+        state=$$(/ci/bin/docker inspect --format '{{.State.Status}}' preflight-app)
+        echo "preflight-app: $$state"
+        if [ "$$state" != running ]; then
+          /ci/bin/docker logs preflight-app || true
+          exit 1
+        fi
+
+        # 本番の smoke test と同じく、コンテナ名ではなく network 上の IP で引く
+        ip=$$(/ci/bin/docker inspect \
+          --format '{{index .NetworkSettings.Networks "cloudbuild" "IPAddress"}}' \
+          preflight-app)
+        echo "preflight-app ip: $$ip"
+
         cat > /ci/reachability.pl <<'REACH'
         use HTTP::Tiny;
+        my ($$ip) = @ARGV;
+        $$ip =~ /\A[0-9]+(?:\.[0-9]+){3}\z/ or die "no ip on the cloudbuild network\n";
         my $$r;
-        for (1 .. 15) {
+        for (1 .. 10) {
           $$r = HTTP::Tiny->new(timeout => 5, proxy => undef, http_proxy => undef)
-            ->get('http://preflight-app:8080/');
+            ->get("http://$$ip:8080/");
           last if $$r->{success};
           sleep 2;
         }
-        die "unreachable: $$r->{status} $$r->{reason}\n" unless $$r->{success};
+        # 599 は HTTP::Tiny の内部例外で、実際の原因は content 側に入る
+        die "unreachable: $$r->{status} $$r->{reason}: $$r->{content}\n"
+            unless $$r->{success};
         die "unexpected body: $$r->{content}\n" unless $$r->{content} eq 'preflight-ok';
         print "reachability OK\n";
         REACH
-        exec perl /ci/reachability.pl                                  # (6)
+        exec perl /ci/reachability.pl "$$ip"                            # (6)
 
   - id: cleanup
     name: 'gcr.io/cloud-builders/gcloud'

--- a/docs/cloud-run.md
+++ b/docs/cloud-run.md
@@ -9,18 +9,21 @@ perldoc.jp を Google Cloud Run で動かすための構成と、初期セット
 [perldoc-jp/perldoc.jp]  --push--------------------------┤
 [schedule: 日次保険]  ───────────────────────────────────┤
                                                          v
-                GitHub Actions (.github/workflows/deploy.yml)
-                  WIF 認証 → translation の HEAD 解決
-                  → Cloud Build を github.sha 固定で submit
+                GitHub Actions / years ジョブ (deploy.yml)
+                  translation の HEAD 解決
+                  → data/years.pl を再導出し、差分があれば master へ commit
+                  → 使うコミットと translation の SHA を出力
+                                                         v
+                GitHub Actions / deploy ジョブ (deploy.yml)
+                  WIF 認証 → その commit を固定して Cloud Build を submit
                                                          v
                 Cloud Build (asia-northeast1 / cloudbuild.yaml)
                   translation取得 → SQLite構築 → データ生成
                   → テスト → Docker build → Artifact Registry push
-                  → smoke test → years-export
+                  → smoke test
                                                          v
-                GitHub Actions (.github/workflows/deploy.yml)
-                  years.pl を取得 → Cloud Run deploy
-                  → commit-years-data が data/years.pl を master へ
+                GitHub Actions / deploy ジョブ (deploy.yml)
+                  Cloud Run deploy
                                                          v
 [ユーザー] → Cloudflare (Worker) → Cloud Run (asia-northeast1)
                            - min-instances=0 (無アクセス時のコストほぼゼロ)
@@ -30,14 +33,19 @@ perldoc.jp を Google Cloud Run で動かすための構成と、初期セット
 ```
 
 - **イメージのビルドは Cloud Build (asia-northeast1) で行う** (§11)。GitHub-hosted
-  runner でビルドしていた頃は、buildcache の pull・smoke test のための image pull・
-  years-export の cache pull がいずれも Artifact Registry からインターネットへ出る
-  data transfer out になっていた。同一ロケーション内の転送は無料なので、数百 MB〜GB
-  級のレイヤ転送を asia-northeast1 の中に閉じ込める。
+  runner でビルドしていた頃は、buildcache の pull と smoke test のための image pull が
+  どちらも Artifact Registry からインターネットへ出る data transfer out になっていた。
+  同一ロケーション内の転送は無料なので、数百 MB〜GB 級のレイヤ転送を
+  asia-northeast1 の中に閉じ込める。
   `script/smoke-test.pl` は手元に無いイメージを `docker run` の自動 pull で取りに行く
   ため、ビルドだけを移して smoke test を GitHub Actions に残す分割では転送は消えない。
   Cloud Run への deploy は GitHub Actions 側に残す (WIF の境界を維持し、Cloud Build の
   サービスアカウントに Cloud Run の権限を持たせないため)。
+- **`data/years.pl` はビルドの前に更新する**。deploy.yml の years ジョブが
+  `script/update-years.pl` で再導出し、差分があれば master へコミットしてから、
+  その commit をソースにしてビルドする。ビルドから成果物を取り出して GitHub へ
+  運ぶ経路を持たないので、イメージが読む years.pl とリポジトリにコミットされて
+  いるものは常に同じ現物になる。
 - データ更新は「イメージ再ビルド + 再デプロイ」に一本化されている。VPS 時代の
   cron (10分毎の script/update.pl) に相当する処理は Dockerfile の databuild
   ステージが担う。
@@ -106,12 +114,11 @@ gcloud billing projects link "$PROJECT_ID" \
 
 gcloud services enable --project="$PROJECT_ID" \
   run.googleapis.com artifactregistry.googleapis.com \
-  cloudbuild.googleapis.com storage.googleapis.com \
+  cloudbuild.googleapis.com \
   iam.googleapis.com iamcredentials.googleapis.com sts.googleapis.com
 ```
 
-`cloudbuild.googleapis.com` は §11 のイメージビルド、`storage.googleapis.com` は
-§11 の years.pl 受け渡し用バケットが使う。
+`cloudbuild.googleapis.com` は §11 のイメージビルドが使う。
 
 `compute.googleapis.com` は有効化しない。Cloud Run のランタイムには専用のサービス
 アカウントを作る (§3) ため、Compute Engine のデフォルト SA を使わない。Cloud Build も
@@ -356,10 +363,9 @@ deploy.yml が上記 2 つの secret から組み立てるため、個別には�
 (project number / ID の重複保存を避ける)。
 
 同じ理由で、Cloud Build 移行 (§11) でも **secret も variable も増やしていない**。
-builder SA email (`perldoc-jp-builder@<PROJECT_ID>.iam.gserviceaccount.com`) と
-years 成果物バケット名 (`<PROJECT_ID>-build-artifacts`) は deploy.yml が
-`GCP_PROJECT_ID` から組み立て、`cloudbuild.yaml` 側は built-in の `$PROJECT_ID`
-substitution を使う (リポジトリのファイルに project ID を書かない)。
+builder SA email (`perldoc-jp-builder@<PROJECT_ID>.iam.gserviceaccount.com`) は
+deploy.yml が `GCP_PROJECT_ID` から組み立て、`cloudbuild.yaml` 側は built-in の
+`$PROJECT_ID` substitution を使う (リポジトリのファイルに project ID を書かない)。
 Cloud Build が fetch するソースの URL は公開リポジトリのものなので機密ではない。
 
 environment は workflow から参照されただけでも自動作成されるが、その場合は
@@ -470,14 +476,14 @@ EOF
 gh api repos/perldoc-jp/perldoc.jp/rules/branches/master
 ```
 
-pull request 必須ルールは入れていない。deploy.yml の commit-years-data が
+pull request 必須ルールは入れていない。deploy.yml の years ジョブが
 GITHUB_TOKEN で master へ直接 push するため、PR 必須にするには push の PR 化か
 bypass 用の専用 App が必要になり、単独メンテの merge も止まるため。
 したがって「write 権限を持つアカウントの侵害」に対する独立レビュー境界は
 現状存在しない (承認 0 の PR 必須を足してもこの境界にはならない)。
 メンテナが増えたときに required approvals + CODEOWNERS へ引き上げる。
 同じ ruleset を translation リポジトリの master にも適用する (GitHub App の
-private key を置くため。§9)。適用直後の Deploy workflow で commit-years-data の
+private key を置くため。§9)。適用直後の Deploy workflow で years ジョブの
 push が成功することを確認すること。
 
 ### 8. 手動でのビルドとデプロイ
@@ -662,7 +668,7 @@ App token (`Actions: write`) が侵害されたときにできることは dispa
 - deploy.yml / deploy-worker.yml の dispatch と、レビュー済み master の再デプロイ
 - 既存 run の再実行 (初回実行から 30 日以内。元の actor の権限・元の SHA/ref で
   走る)・キャンセル、workflow の停止・再開、run / artifact の操作
-- deploy.yml 経由での commit-years-data の起動 (= レビュー済みコードが生成する
+- deploy.yml 経由での years ジョブの起動 (= レビュー済みコードが生成する
   派生データ data/years.pl の master へのコミットまでは到達する)
 - `ref` は API 上 master 以外の**既存** ref も指定できる (`-f ref=master` は
   呼び出し側の慣行であって token の制約ではない)。ただし別 ref への dispatch は、
@@ -1124,17 +1130,21 @@ Worker を挟まない構成にする場合の選択肢:
 
 ### 11. Cloud Build (本番イメージのビルド)
 
-`.github/workflows/deploy.yml` は、ビルド・テスト・smoke test・years-export を
+`.github/workflows/deploy.yml` の deploy ジョブは、ビルド・テスト・smoke test を
 Cloud Build (`cloudbuild.yaml`) に投げる。GitHub-hosted runner が Artifact Registry から
 buildcache や runtime イメージを引くと、そのたびにインターネットへの data transfer out に
 なるため、大きいレイヤ転送を asia-northeast1 の中で完結させる。
+
+ビルドの成果物を Cloud Build から GitHub へ運ぶ経路は持たない。`data/years.pl` は
+その前段の years ジョブが `script/update-years.pl` で再導出して master へコミットし、
+その commit をソースにしてビルドするので、イメージはコミット済みの現物を読む。
 
 ソースは 2nd-gen の GitHub connection を使わず、**公開リポジトリの exact commit SHA を
 Cloud Build 自身に fetch させる** (`gcloud builds submit <URL> --git-source-revision <SHA>`)。
 `--config` に渡す `cloudbuild.yaml` だけは gcloud が手元から読んで Build を組み立てる
 (ビルドの定義は呼び出し側、ビルドコンテキストは Cloud Build が fetch したもの)。
-deploy.yml は `actions/checkout` した作業ツリーから渡すので、どちらも同じ
-`github.sha` になる。
+deploy.yml は years ジョブが出力した commit を `actions/checkout` してから渡すので、
+どちらも同じ commit になる。
 connection 方式は Cloud Build GitHub App のインストールと、Secret Manager 上に置かれる
 GitHub ユーザーの OAuth トークンを常設で必要とする。このリポジトリは公開なので、
 そのどれも持たずに済ませる。ローカルの checkout を送る `gcloud builds submit .` も使わない
@@ -1142,7 +1152,7 @@ GitHub ユーザーの OAuth トークンを常設で必要とする。このリ
 
 §2 (Artifact Registry) と §5 (デプロイ用 SA) の後に、**この順で**実行する。
 
-#### 11-1. builder サービスアカウントと成果物バケット
+#### 11-1. builder サービスアカウント
 
 preflight (11-2) は builder SA を指定して回すので、SA と最低限の IAM が先に要る。
 
@@ -1166,29 +1176,8 @@ builder SA には **Cloud Run の権限を一切与えない**。デプロイは
 残してあり (§5 の WIF が持つ「master かつ deploy.yml からのみ」という境界を維持するため)、
 ビルド側にその境界を跨がせない。
 
-`data/years.pl` を GitHub Actions へ戻すための小さなバケットを作る。ソースの staging には
-使わない (そもそも staging bucket を作らせない構成にしてある)。
-
-```sh
-# soft delete は既定 7 日で、削除済みオブジェクトもその間は課金対象になる。
-# 1 ビルドで作って直後に消す用途なので 0 にする
-gcloud storage buckets create "gs://${PROJECT_ID}-build-artifacts" \
-  --project="$PROJECT_ID" --location="$REGION" \
-  --uniform-bucket-level-access --public-access-prevention \
-  --soft-delete-duration=0
-
-# GitHub Actions 側の削除が落ちた場合の保険。1 日で自動削除する
-# (lifecycle による削除は無料オペレーション)
-cat > /tmp/years-lifecycle.json <<'EOF'
-{"rule":[{"action":{"type":"Delete"},"condition":{"age":1}}]}
-EOF
-gcloud storage buckets update "gs://${PROJECT_ID}-build-artifacts" \
-  --lifecycle-file=/tmp/years-lifecycle.json
-
-# アップロードだけできればよい (読み出しと削除は GitHub Actions 側の SA が行う)
-gcloud storage buckets add-iam-policy-binding "gs://${PROJECT_ID}-build-artifacts" \
-  --member="serviceAccount:$BUILDER_SA" --role=roles/storage.objectCreator
-```
+Cloud Storage は使わない。ビルドの成果物を GitHub へ運ぶ経路が無いので専用バケットは
+不要で、`gcloud builds submit .` を使わないためソースの staging bucket も作られない。
 
 #### 11-2. preflight (cutover の必須前提)
 
@@ -1202,7 +1191,7 @@ cutover すること。ローカルエミュレータ (`cloud-build-local`) の�
 - Cloud Build は各ステップのコンテナを `cloudbuild` という docker network に接続する
 - ステップの image に Google 提供でない public / custom image を使える
 
-preflight で確かめるのは次の 8 点:
+preflight で確かめるのは次の 7 点:
 
 1. ステップから `/var/run/docker.sock` が使える
 2. named volume がステップ間で共有される
@@ -1218,9 +1207,6 @@ preflight で確かめるのは次の 8 点:
    `perl:5.42-trixie` でも実行でき、そこから docker socket を使える
    (smoke test のステップがまさにこの組み合わせ。ここが崩れると、ビルドと push が
    終わった後の一番高くつく地点で落ちる)
-8. builder SA の `roles/storage.objectCreator` だけで `gcloud storage cp` が通る
-   (production では years.pl のアップロードが最後のステップなので、権限不足だと
-   ビルド全体を捨てることになる)
 
 `docker:<VERSION>-cli` への buildx プラグインの同梱と、取り出す 2 つのバイナリが
 静的リンクであることは、image の config と ELF ヘッダで確認済みなので未確認項目には
@@ -1331,23 +1317,6 @@ steps:
         REACH
         exec perl /ci/reachability.pl                                  # (6)
 
-  # production の最後のステップと同じ経路で、builder SA の
-  # roles/storage.objectCreator だけで書けることを確かめる。
-  # 置いたオブジェクトはバケットの lifecycle (age 1) が翌日に回収する
-  - id: years-upload
-    name: 'gcr.io/cloud-builders/gcloud'
-    entrypoint: 'bash'
-    volumes:
-      - name: 'ci'
-        path: '/ci'
-    env:
-      - 'OBJECT=gs://$PROJECT_ID-build-artifacts/preflight/$BUILD_ID.txt'
-    args:
-      - -ceu
-      - |
-        printf 'preflight' > /ci/years-probe.txt
-        gcloud storage cp /ci/years-probe.txt "$$OBJECT"               # (8)
-
   - id: cleanup
     name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
@@ -1408,10 +1377,6 @@ gcloud projects add-iam-policy-binding "$PROJECT_ID" \
 gcloud iam service-accounts add-iam-policy-binding "$BUILDER_SA" \
   --project="$PROJECT_ID" \
   --member="serviceAccount:$SA" --role=roles/iam.serviceAccountUser
-
-# years.pl の取得と、取得後の削除
-gcloud storage buckets add-iam-policy-binding "gs://${PROJECT_ID}-build-artifacts" \
-  --member="serviceAccount:$SA" --role=roles/storage.objectUser
 ```
 
 任意: ビルドログを GitHub Actions のログに出したい場合。`cloudbuild.yaml` は
@@ -1457,13 +1422,12 @@ gcloud artifacts repositories add-iam-policy-binding perldoc-jp \
 
 リポジトリのコードだけでは完結しない操作を、実行順に並べたもの:
 
-1. §1 の API 有効化 (`cloudbuild.googleapis.com` / `storage.googleapis.com` を含む)
+1. §1 の API 有効化 (`cloudbuild.googleapis.com` を含む)
 2. builder SA の作成と IAM (11-1)
-3. years 成果物バケットの作成・lifecycle・IAM (11-1)
-4. preflight ビルド (11-2)
-5. デプロイ用 SA への追加バインディング (11-3)
-6. cutover
-7. デプロイ用 SA の Artifact Registry 権限を writer → reader へ降格 (11-3)
+3. preflight ビルド (11-2)
+4. デプロイ用 SA への追加バインディング (11-3)
+5. cutover
+6. デプロイ用 SA の Artifact Registry 権限を writer → reader へ降格 (11-3)
 
 **GitHub 側の追加操作は無い。secret も variable も増えない** (§7)。
 Cloud Build の 2nd-gen connection、Cloud Build GitHub App のインストール、
@@ -1481,7 +1445,7 @@ Secret Manager はいずれも使わない。
 | Artifact Registry ↔ Cloud Build (同一ロケーション) | **$0.00 (Free)**。"Data moves within the same location" に該当し、Cloud Build への data transfer in も無料 | **この変更の主目的**。buildcache の pull・イメージの push・smoke test のための pull がすべてここに入る |
 | Artifact Registry → インターネット (Premium Tier data transfer out) | 宛先別の階梯。North America 宛: 0〜1 GiB 無料 / 1〜1,024 GiB $0.12 / 1,024〜10,240 GiB $0.11 / 10,240 GiB 超 $0.08。Europe 宛と Asia 宛 (Korea・Indonesia を除く): 0〜1 GiB 無料 / $0.12 / $0.11 / $0.085。Australia・Indonesia・Korea・South America・Saudi Arabia 宛: $0.19 / $0.18 / $0.15。Middle East (Saudi Arabia を除く)・Africa 宛: 0〜1 GiB 無料 / $0.15 / $0.13 / $0.11。China 宛 (香港を除く): $0.23 / $0.22 / $0.20。data transfer in は無料 | **削減対象**。GitHub-hosted runner は Google のサービスではないので、runner が引くイメージ・キャッシュはここに入っていた。料金表は転送元リージョンで値が変わる (ページにセレクタがある) ため、`asia-northeast1` を選んだ実際の値で確認すること |
 | Cloud Logging | $0.50/GiB、**50 GiB/project/month が無料**。`_Default` バケットの既定保持期間 (30 日) には保持料金がかからない | `logging: CLOUD_LOGGING_ONLY` にしたビルドログの分。無料枠に収まる想定 |
-| Cloud Storage (years 成果物バケット) | asia-northeast1 の Standard は $0.000027397/GiB-hour (約 $0.020/GiB-month)。Class A $0.005/1,000 ops、Class B $0.0004/1,000 ops。**Always Free は US-WEST1 / US-CENTRAL1 / US-EAST1 のみで asia-northeast1 は対象外**。lifecycle と API による削除は無料オペレーション | `data/years.pl` は 1 MB 未満で、ビルドごとに書き込み 1 回・読み出し 1 回・削除 1 回。オブジェクトは取得直後に消え、取り逃しても 1 日で lifecycle が回収するので、保存容量はほぼ常にゼロ |
+| Cloud Storage | — | **使わない**。ビルドの成果物を GitHub へ運ぶ経路が無いので専用バケットは要らず、`gcloud builds submit .` を使わないためソースの staging bucket も作られない |
 | Artifact Analysis (脆弱性スキャン) | $0.26/scan。**Container Scanning API を有効化したときにだけ**課金が始まる。digest 単位で初回 push のみ課金され、タグの付け替えは無課金 | §1 で同 API を有効化していないため、**この変更で新たに発生する費用ではない**。有効化した場合も、push 元が GitHub Actions か Cloud Build かで差は出ない |
 
 避けている費用:
@@ -1527,7 +1491,7 @@ workflow_dispatch (§9) で受けるため、翻訳がマージされてから�
   リポジトリに 60 日間アクティビティが無いと GitHub により自動で無効化される。
   perldoc.jp 本体はコミット頻度が低く、translation の更新 (workflow_dispatch)
   はこの判定のアクティビティにならないため、「日次保険」だけが黙って止まる
-  ことがある (commit-years-data ジョブの自動コミットはアクティビティになるため、
+  ことがある (years ジョブの自動コミットはアクティビティになるため、
   translation の更新が続いている限りは起きにくい)。Actions タブの Deploy workflow に無効化の告知が出ていたら
   re-enable すること (workflow_dispatch 起動は無効化の
   対象外なので、translation 起点の反映は止まらない)
@@ -1598,17 +1562,18 @@ workflow_dispatch (§9) で受けるため、翻訳がマージされてから�
   (「この変更で課金対象になり得るもの」参照)。所要時間は
   `gcloud builds list --project <PROJECT_ID> --region asia-northeast1 --limit 20 --format='table(id,status,createTime,startTime,finishTime)'`
   で確認する
-- **data/years.pl の自動更新 (年次作業は不要)**: databuild は `create_data.pl`
-  で前年+当年 (対象年は translation の最新イベントから導出) を毎ビルド
-  translation の git 履歴から再導出し、デプロイ成功後に
-  `commit-years-data` ジョブが再導出結果を master へ自動コミットする
-  (変更がある場合のみ。実装は `.github/workflows/deploy.yml` の同名ジョブ)。
-  コミットの親は artifact の生成元と同じ `github.sha` に固定してあり、
-  push の時点で master が進んでいればその run の artifact は捨てる。
+- **data/years.pl の自動更新 (年次作業は不要)**: `.github/workflows/deploy.yml` の
+  years ジョブが、イメージをビルドする前に `script/update-years.pl` で前年+当年
+  (対象年は translation の最新イベントから導出) を translation の git 履歴から
+  再導出し、差分があれば master へ自動コミットする。ビルドはそのコミットを
+  ソースにするので、リポジトリにある years.pl とイメージが読むものは同じ現物になる。
+  コミットの親は `github.sha` に固定してあり、push の時点で master が進んでいれば
+  その run の再導出結果は捨てて `github.sha` のままビルドする (master が進んだ
+  ということは後続の run があり、書き戻しはそちらに任せる)。
   再導出されるのは前年+当年だけなので、この書き戻しが
   無いと、ある年の統計は 2 年後にシードのコミット時点の内容で凍結されてしまう。
   自動コミットが止まっていた場合も、対象年の翌年中に一度
-  `perl script/create_data.pl <対象年>` の結果をコミットすれば回復する。
+  `perl script/update-years.pl <対象年>` の結果をコミットすれば回復する。
   対象年を過去に指定すればその年以降を git 履歴からまとめて再導出できる。
   ただし**指定してよいのは 2023 年以降**。
   2022 年以前は CVS 期の別実装が書いた記録で、**現在の git 履歴からは同じ値を

--- a/docs/cloud-run.md
+++ b/docs/cloud-run.md
@@ -1431,13 +1431,16 @@ gcloud artifacts repositories add-iam-policy-binding perldoc-jp \
 
 1. §1 の API 有効化 (`cloudbuild.googleapis.com` を含む)
 2. builder SA の作成と IAM (11-1)
-3. preflight ビルド (11-2)
-4. デプロイ用 SA への追加バインディング (11-3)
-5. cutover
-6. デプロイ用 SA の Artifact Registry 権限を writer → reader へ降格 (11-3)
+3. GitHub の environment `master-write` の作成 (§7)
+4. preflight ビルド (11-2)
+5. デプロイ用 SA への追加バインディング (11-3)
+6. cutover
+7. デプロイ用 SA の Artifact Registry 権限を writer → reader へ降格 (11-3)
 
-**GitHub 側で必要なのは environment `master-write` の作成だけ** (§7 の environment
-作成コマンドに含めてある)。secret も variable も増えない。
+**GitHub 側で必要なのは 3 の environment だけ** (§7 の environment 作成コマンドに
+含めてある)。secret も variable も増えない。作らずに参照されると branch policy 無しで
+自動作成され、years ジョブの master 限定の境界が黙って無くなるので、cutover の前に
+必ず作ること。
 Cloud Build の 2nd-gen connection、Cloud Build GitHub App のインストール、
 Secret Manager はいずれも使わない。
 
@@ -1550,10 +1553,12 @@ workflow_dispatch (§9) で受けるため、翻訳がマージされてから�
   Deploy workflow 側がキャンセル・失敗した場合は workflow が自動で cancel する。
   そのとき対象を引くのに使っているのは build ID ではなく run ごとに一意な
   `_TAG` substitution で、`gcloud builds submit` が ID を返す前に中断されても
-  受理済みのビルドを回収できるようにしてある。手で探す場合も同じ引き方をする:
+  受理済みのビルドを回収できるようにしてある。`_TAG` の先頭は `github.sha` では
+  なく **実際にビルドした commit** (years ジョブが書き戻していればその commit)。
+  手で探す場合も同じ引き方をする:
   ```sh
   gcloud builds list --project <PROJECT_ID> --region asia-northeast1 --ongoing \
-    --filter='substitutions._TAG=<GITHUB_SHA>-<RUN_ID>-<RUN_ATTEMPT>' \
+    --filter='substitutions._TAG=<ビルドした commit>-<RUN_ID>-<RUN_ATTEMPT>' \
     --format='value(id)'
   ```
   進行中のものを全部見たいときは `--filter` を外す。放置すると、次の run のビルドと

--- a/docs/cloud-run.md
+++ b/docs/cloud-run.md
@@ -357,6 +357,11 @@ region は既にリポジトリ履歴で公開なので secret にしない (今
 | `CLOUD_RUN_URL` | environment `cloudflare-production` の secret (§10 の Worker のオリジン) |
 | `CLOUDFLARE_API_TOKEN` | environment `cloudflare-production` の secret |
 
+environment `master-write` は secret を持たない。deploy.yml の years ジョブが
+`data/years.pl` を master へ直接 push するため、その ref を master に限定する
+ためだけに置く (yml 内の ref ガードは workflow_dispatch では yml ごと
+差し替えられるので境界にならない。下の `CLOUDFLARE_API_TOKEN` の項と同じ理由)。
+
 WIF provider (`projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/github/providers/perldoc-jp`)
 と SA email (`perldoc-jp-deployer@<PROJECT_ID>.iam.gserviceaccount.com`) は
 deploy.yml が上記 2 つの secret から組み立てるため、個別には保存しない
@@ -370,16 +375,18 @@ Cloud Build が fetch するソースの URL は公開リポジトリのもの�
 
 environment は workflow から参照されただけでも自動作成されるが、その場合は
 branch policy の無い素通しになり、environment に secret が無ければ同名の
-repository secret にフォールバックする。**必ず両方の environment を作って
-branch policy を付けてから secret を置くこと**。順序も固定で、environment の
-作成が先 (`gh secret set --env` は既存 environment の public key を取得して
+repository secret にフォールバックする。**必ず 3 つの environment を作って
+branch policy を付けてから secret を置くこと**。`master-write` は secret を
+持たないが、作らずに参照されると branch policy 無しで自動作成され、master 限定の
+境界が黙って無くなる。順序も固定で、environment の作成が先
+(`gh secret set --env` は既存 environment の public key を取得して
 暗号化するため、environment が無ければ 404 で失敗する):
 
 ```sh
 # environment の作成。custom branch policy を使う (protected_branches=true は
 # 「保護ルールを持つ全ブランチを許可」の意味で、後からどこかのブランチに
 # 保護ルールを足すと許可範囲も一緒に広がってしまう)
-for env in gcp-production cloudflare-production; do
+for env in gcp-production cloudflare-production master-write; do
   gh api --method PUT "repos/perldoc-jp/perldoc.jp/environments/$env" \
     -F 'deployment_branch_policy[protected_branches]=false' \
     -F 'deployment_branch_policy[custom_branch_policies]=true'
@@ -1429,7 +1436,8 @@ gcloud artifacts repositories add-iam-policy-binding perldoc-jp \
 5. cutover
 6. デプロイ用 SA の Artifact Registry 権限を writer → reader へ降格 (11-3)
 
-**GitHub 側の追加操作は無い。secret も variable も増えない** (§7)。
+**GitHub 側で必要なのは environment `master-write` の作成だけ** (§7 の environment
+作成コマンドに含めてある)。secret も variable も増えない。
 Cloud Build の 2nd-gen connection、Cloud Build GitHub App のインストール、
 Secret Manager はいずれも使わない。
 
@@ -1463,7 +1471,7 @@ VPS で `PLACK_ENV=deployment` の crontab が回していたジョブと、移�
 |---|---|---|
 | `update_deployment.sh` (= `script/update.pl`) | 1日4回 (3〜6時台) | Dockerfile の databuild ステージ。translation への push で即時、加えて日次 schedule |
 | `script/create_recent.pl` | 毎時 | 同上 (databuild)。`script/create_data.pl` に統合 |
-| `script/create_year_data.pl $(date +%Y)` | 毎日 4:05 | 同上 (databuild)。`script/create_data.pl` に統合。ターゲットは translation の最新イベントの前年 (script 側で導出) に変更し、前年+当年を毎ビルド git から再導出する (年またぎの欠落を自己修復) |
+| `script/create_year_data.pl $(date +%Y)` | 毎日 4:05 | `script/update-years.pl`。deploy.yml の years ジョブがイメージのビルドより前に実行し、結果を master へコミットする。ターゲットは translation の最新イベントの前年 (script 側で導出) に変更し、前年+当年を毎回 git から再導出する (年またぎの欠落を自己修復) |
 | `script/create_docs.json.sh` | 6時間毎 | 同上。`script/create_data.pl` に置き換え |
 | `script/generate_heavy_diff.pl` | 毎時 | **廃止**。diff 計算を GNU diff 外部コマンド化 (`PJP::HTMLDiff`) で高速化したため都度計算で足り、同じ比較の反復は Cloudflare のエッジキャッシュ (§10) が吸収する |
 | `script/scrape_cpan.pl` | (コメントアウト済み) | 廃止 |
@@ -1585,10 +1593,12 @@ workflow_dispatch (§9) で受けるため、翻訳がマージされてから�
   ハイフンを 1 個だけ `::` にしていた頃の値) が残るが、表示だけの差で
   件数や翻訳者ごとの集計は変わらない (同一性の判定は
   `PJP::M::YearData::_dedup_in` が両方の表記を同じものとして扱う)
-- **`data/years.pl` の完全性 (cutover の必須前提)**: `create_data.pl` は
+- **`data/years.pl` の完全性 (cutover の必須前提)**: `update-years.pl` は
   既存の `data/years.pl` のうち対象年より前だけを seed として取り込み、
-  対象年以降は毎ビルド git 履歴から再構築する (イベントが削除だけになった年の
-  ブロックは残らない)。2022 年以前の統計は CVS と複数の旧リポジトリを当時の
+  対象年以降を git 履歴から再構築する (イベントが削除だけになった年の
+  ブロックは残らない)。イメージのビルド (databuild) はこのファイルを再生成せず、
+  コミットされている現物をそのまま取り込む。
+  2022 年以前の統計は CVS と複数の旧リポジトリを当時の
   システムで観測した結果の凍結で、現在の git 履歴からは再現できないため、
   過去年を含む現物が **git 管理下にコミットされていること** が前提になる。
   ローカルビルドで `/translators` が 200 を返しても、それはページが

--- a/script/create_data.pl
+++ b/script/create_data.pl
@@ -1,11 +1,18 @@
 #!/usr/bin/perl
 
-# databuild の派生データ (recent feed / 年次統計 / docs.json / 目次) を
-# 1 プロセスで生成する。翻訳イベントの導出は translation の git log 全走査で
-# 高価なうえ、空チェックと shadowed-deletion 検査という不変条件を伴う。
-# 生成物ごとに別プロセスで導出すると走査が重複し、検査の適用が生成物ごとに
-# 非対称になるため、導出と検査をここで 1 回だけ行い、すべての生成物を同じ
-# 検査済みイベント列から組み立てる。
+# databuild の派生データ (recent feed / docs.json / 目次) を 1 プロセスで生成する。
+# 翻訳イベントの導出は translation の git log 全走査で高価なうえ、空チェックと
+# shadowed-deletion 検査という不変条件を伴う。生成物ごとに別プロセスで導出すると
+# 走査が重複し、検査の適用が生成物ごとに非対称になるため、導出と検査をここで
+# 1 回だけ行い、すべての生成物を同じ検査済みイベント列から組み立てる。
+#
+# 年次統計 (data/years.pl) だけは main から外してある。イメージのビルドより前に
+# 再導出して master へコミットし、そのコミットをソースにしてビルドする構成のため
+# (.github/workflows/deploy.yml の years ジョブと script/update-years.pl)。
+# ここでも再生成すると、コミットされている現物とイメージの中身が食い違いうる。
+# その分だけ走査が 2 プロセスに分かれるので、update-years.pl 側にも同じ
+# 空チェックを置いてある。create_year_data 自体はここに残し、導出のロジックが
+# 1 箇所であることは保つ
 
 use strict;
 use warnings;
@@ -38,7 +45,7 @@ sub main {
     mkdir './data' or die $! if not -d './data';
 
     create_recent($pjp, $events);
-    create_year_data($events, $ARGV[0]);
+    # create_year_data はここから呼ばない (冒頭のコメント参照)
     create_docs_json($pjp);
     create_index_data($pjp, $events);
 }
@@ -118,6 +125,7 @@ sub create_rss {
     });
 }
 
+# 呼ぶのは script/update-years.pl だけ (main からは呼ばない)
 sub create_year_data {
     my ($events, $target_year) = @_;
 

--- a/script/smoke-test.pl
+++ b/script/smoke-test.pl
@@ -113,15 +113,10 @@ SH
 
     # CI ランナー自身がコンテナの中にいる場合 (Cloud Build)、ホストの loopback へ
     # publish してもランナーの network namespace からは届かない。
-    # SMOKE_DOCKER_NETWORK が指定されたときは同じ docker network に相乗りし、
-    # 埋め込み DNS でコンテナを引く。
-    # 名前は File::Temp の X 展開により大文字と `_` を含みうるため、DNS ラベルとして
-    # 安全な小文字の別名を付けてそちらで引く (名前そのものは衝突回避の予約として
-    # 使い続けるので、正規化で一意性は落ちない)。
-    # DNS が case-insensitive であることや docker の resolver の実装に賭けない
+    # SMOKE_DOCKER_NETWORK が指定されたときは同じ docker network に相乗りする。
+    # 接続先はコンテナ名ではなく network 上の IP を使う。docker の埋め込み DNS が
+    # その network で効くかどうか (コンテナ名の文字種の扱いを含む) に依存させない
     my $network = $ENV{SMOKE_DOCKER_NETWORK} // '';
-    my $alias = lc($name) =~ s/[^a-z0-9-]/-/gr;
-    $alias =~ s/-+\z//;
 
     my ($cleanup_needed, $started, $completed);
     defer {
@@ -145,7 +140,7 @@ SH
     # (make up) が bind している最中や並行実行と衝突する。127.0.0.1 への bind なので
     # テスト中のコンテナが LAN に公開されることもない
     my @network_args = $network ne ''
-        ? ('--network', $network, '--network-alias', $alias)
+        ? ('--network', $network)
         : ('-p', '127.0.0.1::8080');
 
     my ($run_ok) = capture(qw(docker run -d --name), $name, @platform,
@@ -155,13 +150,24 @@ SH
 
     my $base;
     if ($network ne '') {
-        # publish 経路の docker port に相当する生存確認。これが無いと、起動直後に
-        # 死んだコンテナでも名前解決の失敗を readiness ループの上限まで繰り返す
-        my ($state_ok, $state) = capture(
-            qw(docker inspect --format {{.State.Running}}), $name);
-        chomp $state;
-        $state_ok && $state eq 'true' or die "コンテナが起動直後に停止した\n";
-        $base = "http://$alias:8080";
+        # 生存確認と IP の取得を 1 回の inspect でまとめる。生存確認は publish 経路の
+        # docker port に相当し、これが無いと起動直後に死んだコンテナでも readiness
+        # ループの上限まで繰り返してしまう。
+        # network 名はドット記法だとハイフンを含む名前で壊れるので index で引く
+        # 区切りは改行にする。値に空白を含む Go テンプレートの <no value> が
+        # 分割されて診断メッセージが切れないようにする
+        my $format = qq[{{.State.Running}}\n]
+            . qq[{{index .NetworkSettings.Networks "$network" "IPAddress"}}];
+        my ($inspect_ok, $inspected) = capture(
+            qw(docker inspect --format), $format, $name);
+        chomp $inspected;
+        my ($running, $ip) = split /\n/, $inspected;
+        $inspect_ok && ($running // '') eq 'true'
+            or die "コンテナが起動直後に停止した\n";
+        # network に繋がっていない場合、Go テンプレートは <no value> を出す
+        ($ip // '') =~ /\A[0-9]+(?:\.[0-9]+){3}\z/
+            or die "network '$network' 上の IP を取得できない (" . ($ip // '') . ")\n";
+        $base = "http://$ip:8080";
     }
     else {
         my ($port_ok, $port) = capture(qw(docker port), $name, '8080/tcp');

--- a/script/smoke-test.pl
+++ b/script/smoke-test.pl
@@ -1,9 +1,13 @@
 #!/usr/bin/env perl
 # ビルド済みイメージを Cloud Run 相当の FS 制約 (--read-only + /tmp の tmpfs) で
-# 起動し、主要経路の開通を確認する。deploy.yml (デプロイ前の検証) と test.yml
-# (PR での runtime ビルド検証) が共用する。
+# 起動し、主要経路の開通を確認する。cloudbuild.yaml (Cloud Build 上での、デプロイ前の
+# 検証) と test.yml (PR での runtime ビルド検証) が共用する。
 #
 # 使い方: script/smoke-test.pl <image>
+#
+# 環境変数 SMOKE_DOCKER_NETWORK を指定すると、コンテナをホストへ publish せず
+# その docker network に載せて検査する。CI ランナー自身がコンテナの中にいて
+# ホストの loopback に届かない環境 (Cloud Build) 用。未指定時の挙動は従来どおり
 #
 # 結果は TAP で出力する。失敗時は diag で HTTP のステータス・本文の先頭・
 # コンテナのログを出し、CI のログだけで原因を調査できるようにする。
@@ -64,8 +68,7 @@ sub smoke_test ($image) {
     # ホストと異なる platform のイメージ (Apple Silicon から本番の amd64 イメージ
     # を検査する場合など) では docker run のたびに platform mismatch の WARNING が
     # 出る。イメージ自身の platform を明示すると、動作を変えずに抑制できる。
-    # イメージがまだ手元に無ければ従来どおり docker run の自動 pull に任せる
-    # (deploy.yml は push だけで daemon に load しないのでこの分岐を通る)。
+    # イメージがまだ手元に無ければ docker run の自動 pull に任せる。
     # その場合の inspect のエラーは想定内なので stderr に出さない
     open my $stderr_backup, '>&', \*STDERR or die "dup STDERR: $!\n";
     open STDERR, '>', '/dev/null' or die "redirect STDERR: $!\n";
@@ -108,6 +111,18 @@ SH
     );
     my $name = basename $name_reservation->dirname;
 
+    # CI ランナー自身がコンテナの中にいる場合 (Cloud Build)、ホストの loopback へ
+    # publish してもランナーの network namespace からは届かない。
+    # SMOKE_DOCKER_NETWORK が指定されたときは同じ docker network に相乗りし、
+    # 埋め込み DNS でコンテナを引く。
+    # 名前は File::Temp の X 展開により大文字と `_` を含みうるため、DNS ラベルとして
+    # 安全な小文字の別名を付けてそちらで引く (名前そのものは衝突回避の予約として
+    # 使い続けるので、正規化で一意性は落ちない)。
+    # DNS が case-insensitive であることや docker の resolver の実装に賭けない
+    my $network = $ENV{SMOKE_DOCKER_NETWORK} // '';
+    my $alias = lc($name) =~ s/[^a-z0-9-]/-/gr;
+    $alias =~ s/-+\z//;
+
     my ($cleanup_needed, $started, $completed);
     defer {
         cleanup_container(
@@ -126,18 +141,34 @@ SH
 
     $cleanup_needed = 1;
 
-    # ホスト側ポートは固定しない。8080 固定だと docker compose (make up) が
-    # bind している最中や並行実行と衝突する。127.0.0.1 への bind なので
+    # publish する場合、ホスト側ポートは固定しない。8080 固定だと docker compose
+    # (make up) が bind している最中や並行実行と衝突する。127.0.0.1 への bind なので
     # テスト中のコンテナが LAN に公開されることもない
+    my @network_args = $network ne ''
+        ? ('--network', $network, '--network-alias', $alias)
+        : ('-p', '127.0.0.1::8080');
+
     my ($run_ok) = capture(qw(docker run -d --name), $name, @platform,
-        qw(--read-only --tmpfs /tmp -e PORT=8080 -p 127.0.0.1::8080), $image);
+        qw(--read-only --tmpfs /tmp -e PORT=8080), @network_args, $image);
     $run_ok or die "コンテナを起動できない\n";
     $started = 1;
 
-    my ($port_ok, $port) = capture(qw(docker port), $name, '8080/tcp');
-    ($port) = split /\n/, $port;
-    $port_ok && $port or die "公開ポートを取得できない\n";
-    my $base = "http://$port";
+    my $base;
+    if ($network ne '') {
+        # publish 経路の docker port に相当する生存確認。これが無いと、起動直後に
+        # 死んだコンテナでも名前解決の失敗を readiness ループの上限まで繰り返す
+        my ($state_ok, $state) = capture(
+            qw(docker inspect --format {{.State.Running}}), $name);
+        chomp $state;
+        $state_ok && $state eq 'true' or die "コンテナが起動直後に停止した\n";
+        $base = "http://$alias:8080";
+    }
+    else {
+        my ($port_ok, $port) = capture(qw(docker port), $name, '8080/tcp');
+        ($port) = split /\n/, $port;
+        $port_ok && $port or die "公開ポートを取得できない\n";
+        $base = "http://$port";
+    }
     pass "コンテナ起動 (--read-only + tmpfs /tmp, $base)";
 
     # ローカルコンテナだけを検査するので proxy 環境変数を無効化する。

--- a/script/update-years.pl
+++ b/script/update-years.pl
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+
+# data/years.pl だけを translation の git 履歴から再導出して書き戻す。
+# .github/workflows/deploy.yml の years ジョブが、イメージをビルドする前に実行する。
+#
+# 使い方: perl script/update-years.pl [対象年]
+#
+# PJP::M::YearData->build は対象年より前を seed (既存の data/years.pl) から
+# そのまま引き継ぎ、対象年以降だけをイベントから再構築する。対象年は既定で
+# 「translation の最新イベントの前年」なので、この書き戻しが無いと、ある年が
+# 再導出の窓から外れた時点でその年の統計がシードのコミット時点で凍結される。
+# 年をまたぐ前に一度実行されていれば足りるが、デプロイのたびに走らせておけば
+# コミット済みの years.pl とデプロイされるイメージの中身が構造的に一致する。
+#
+# 対象年を明示指定してよいのは 2023 年以降だけ (docs/cloud-run.md の「運用」)。
+# 2022 年以前は CVS 期の別実装が書いた記録で、現在の git 履歴からは再現できない。
+#
+# 生成の各段と不変条件は script/create_data.pl が所有している。ここはその
+# create_year_data だけを呼ぶ薄いラッパで、導出のロジックは持たない
+# (t/CreateData.t が各段を直接呼ぶのと同じ require の作法)。
+# docs.json と目次は DB を要するためここでは作らない。それらはイメージビルドの
+# databuild ステージが create_data.pl 全体を通して作る
+
+use strict;
+use warnings;
+
+use lib qw(./lib);
+
+require './script/create_data.pl';
+
+my $pjp = PJP->bootstrap;
+
+my $events = PJP::M::Repository->commit_events($pjp);
+
+# イベントが 1 件も無いのは translation checkout の異常。空の years.pl を
+# 黙って書き戻すと、以降のビルドがそれをシードにしてしまうので必ず止める
+# (create_data.pl の main が同じ検査をしている)
+die "no translation events found\n" unless @$events;
+
+create_year_data($events, $ARGV[0]);


### PR DESCRIPTION
## 概要

本番イメージのビルドを GitHub-hosted runner から **Cloud Build (asia-northeast1)** へ移し、Artifact Registry からインターネットへ出る data transfer out をなくします。

GitHub-hosted runner でビルドしていると、buildcache の pull と smoke test のための image pull がどちらも `Artifact Registry → インターネット` の転送になります。同一ロケーション内の転送は無料なので、数百 MB〜GB 級のレイヤ転送を `asia-northeast1` の中で完結させます。

`script/smoke-test.pl` は手元に無いイメージを `docker run` の自動 pull で取りに行くため、ビルドだけを移して smoke test を GitHub Actions に残す分割では転送は消えません。build → smoke test までを `cloudbuild.yaml` に寄せています。

Cloud Run への deploy は GitHub Actions 側に残しました。WIF の `attribute-condition` が持つ「master かつ deploy.yml からのみ認証できる」境界を維持するためで、builder サービスアカウントには Cloud Run の権限を一切与えていません。

## ⚠️ マージ前に必要な作業

**このブランチだけでは動きません。** `docs/cloud-run.md` §11 の一度きりの操作が先に必要です。未実施のまま master にマージすると、次の Deploy workflow が `gcloud builds submit` で失敗します（fail-closed なので誤ったイメージがデプロイされることはありません）。

実行順:

1. §1 の API 有効化（`cloudbuild.googleapis.com` を追加）
2. builder SA の作成と IAM（§11-1）
3. **GitHub の environment `master-write` の作成（§7）— マージ前に必須**
4. **preflight ビルド（§11-2）— ここが通るまで cutover しない**
5. deployer SA への追加バインディング（§11-3）
6. cutover
7. post-cutover: deployer SA の Artifact Registry 権限を `writer` → `reader` へ降格（§11-3）

手順 3 は years ジョブが master へ直接 push するための ref 境界です。secret は置きません。**environment は workflow から参照されただけでも branch policy 無しで自動作成される**ため、作り忘れると master 限定の境界が黙って無くなります（yml 内の ref ガードは `workflow_dispatch` では yml ごと差し替えられるので境界になりません。§7 と同じ理由）。

GitHub 側で要るのはこの environment だけで、**secret も variable も増えません**（builder SA 名は既存の `GCP_PROJECT_ID` から組み立て、`cloudbuild.yaml` 側は built-in の `$PROJECT_ID` を使うのでリポジトリに project ID が入りません）。**Cloud Storage も使いません**（専用バケットもソースの staging bucket も作られません）。Cloud Build の 2nd-gen connection・GitHub App のインストール・Secret Manager もいずれも使いません。

## 新しいフロー

```
GitHub Actions / years ジョブ  (environment: master-write / contents: write / WIF なし)
  container: perl:5.42-trixie  (defaults.run.shell: bash)
  translation HEAD 解決 → data/years.pl を再導出
  → 差分があれば master へ commit（GITHUB_TOKEN）
  → 使うコミットと translation の SHA を出力
        │ needs
        ▼
GitHub Actions / deploy ジョブ       (id-token: write / contents: read)
  出力された commit を checkout → WIF 認証
  → gcloud builds submit --git-source-revision=<app-sha> --async
  → 完了待ち（SUCCESS 以外は exit 1 → deploy へ進まない）
  → gcloud builds log → gcloud run deploy
  ※ cancelled() || failure() で gcloud builds cancel

Cloud Build (default pool / E2_STANDARD_2 / CLOUD_LOGGING_ONLY / timeout 3600s)
  setup-tools → configure-docker → build-runtime(--push) → pull-runtime → smoke-test
```

Cloud Build のステップは失敗時点で打ち切られるため、`runtime 完成 → smoke test 成功 → ビルド成功 → deploy` の順序は構造的に保証されます。

## `data/years.pl` をビルドの前に更新する

以前は `years-export` ステージの出力を Cloud Storage 経由で GitHub へ運び、デプロイ成功後に `commit-years-data` が書き戻していました。1 MB 未満のファイル 1 つのために専用バケット・lifecycle・IAM 2 本・cloudbuild と deploy の各ステップを抱える構成で、運ぶものに対して重すぎました。

`PJP::M::YearData->build` は対象年（translation の最新イベントの前年）より前を既存の `data/years.pl` から seed としてそのまま引き継ぎ、対象年以降だけを git 履歴から再構築します。つまり書き戻しに要求されているのは「毎デプロイ」ではなく **「年をまたぐ前に一度」** で、しかも 2023 年以降の再導出は冪等なので、コミット済みの現物とビルド中に再導出したものは同じ値になります。

そこで、ビルドの**後**に成果物を取り出すのをやめ、ビルドの**前**に更新する形にしました。リポジトリにコミットされている years.pl とイメージが読むものが構造的に一致し、受け渡しの経路そのものが要らなくなります。

- `script/update-years.pl` を追加。`create_data.pl` の `create_year_data` だけを呼ぶ薄いラッパで、導出のロジックは持ちません（`t/CreateData.t` が各段を直接呼ぶのと同じ `require` の作法）。`create_year_data` はイベント列と seed だけで動き DB を触らないので、databuild を通さずに生成できます。`docs.json` と目次は DB を要するためここでは作らず、従来どおり databuild が `create_data.pl` 全体を通して作ります。
- **`create_data.pl` の `main` からは `create_year_data` を外しました。** 残したままだと databuild が `data/years.pl` を上書きし、「コミット済みの現物をそのまま使う」形になりません。通常経路では再導出結果が同じなので差は出ませんが、push 競合で書き戻しを捨てて `github.sha` をビルドする経路では、そのコミットに含まれない統計がイメージへ入ります。`create_year_data` の実体は `create_data.pl` に残し、導出のロジックが 1 箇所であることは保っています。
- years ジョブは `container:` を使うため **`defaults.run.shell: bash` を明示**しています。コンテナジョブの `run` は既定が `sh` で、`[[ ]]` が `[[: not found`（終了コード 127）になります。
- years ジョブは Dockerfile の `base` と同じ `perl:5.42-trixie` の中で走らせます。`create_data.pl` は冒頭で `useall 'PJP::M'` するため CPAN 依存一式が要り、ubuntu-latest の system perl とは版が合いません。`local/` は `cpanfile.snapshot` のハッシュで `actions/cache` に載せています（**初回はキャッシュが無いのでフルの `cpm install` が走ります**）。
- `config/build.pl` が `/usr/src/app` の絶対パスを前提にしている（`assets_dir`）ので、設定を CI 用に分岐させず、symlink でイメージの中と同じ配置を作ってそこで走らせます。
- push が競合したら、その run の再導出結果は捨てて `github.sha` のままビルドします。master が進んだということは後続の run があり、書き戻しはそちらに任せます。
- `permissions` の分離は維持しています。リポジトリへ書き込む years ジョブに WIF を渡さず、WIF を扱う deploy ジョブに `contents: write` を与えません。
- **Dockerfile の `years-export` ステージを削除しました。** ビルドから years.pl を取り出す経路が無くなり、これを作るものも読むものも無くなったためです。`test.yml` でこのステージだけを守っていたステップも合わせて削除しています。

## 主な設計判断

- **source は公開 Git URL + exact commit SHA**（`--git-source-revision`）。2nd-gen connection は Cloud Build GitHub App のインストールと Secret Manager 上の GitHub ユーザー OAuth トークンを常設で要求しますが、このリポジトリは公開なのでどちらも不要です。`gcloud builds submit .` も使いません（`gs://<PROJECT_ID>_cloudbuild` にソースが溜まるため）。`--config` の `cloudbuild.yaml` は gcloud が手元から読むので、years ジョブが出力した commit を checkout してから渡します。
- **Artifact Registry の認証は credential helper 方式**。ビルド開始時の 1 個のアクセストークンを全ステップで使い回すと、ビルドが長引いたときに最後の push / cache export だけが失効と競り合います。
- **ビルドログは Cloud Logging**（`CLOUD_LOGGING_ONLY`）。user-specified service account を使うビルドは Google 所有のログバケットを使えず、この設定なら自プロジェクトに GCS のログバケットも作られません。代償として live streaming ができないので、完了後に `gcloud builds log` でまとめて取得します。
- **キャンセルは build ID ではなく run 固有の `_TAG` substitution で引く**。`gcloud builds submit` が ID を返して `$GITHUB_ENV` に書くまでには隙間があり、その間にキャンセルされると受理済みのビルドが回収できなくなるためです。
- **`--provenance=mode=max` を明示**。`docker/build-push-action` は public リポジトリの push で既定的に同じ attestation を付けており（素の buildx の既定は `mode=min`）、成果物の粒度を変えないためです。Cloud Run 側の要件ではありません。`--platform linux/amd64` も、ビルダー VM のアーキテクチャへの暗黙依存をやめて設定で固定しました。
- **外部イメージは digest でピン留め**（`docker:29.7.2-cli` / `moby/buildkit:v0.32.2`）。`perl:5.42-trixie` は Dockerfile の `base` と同じものを使い、新しい供給元を増やしていません。

## 維持したもの

`schedule` / `workflow_dispatch` / push master、`concurrency`、`environment: gcp-production`、ジョブ単位の `permissions` の分離、一意な `TAG`、`request_reason` の監査性、`gcloud run deploy` のフラグ一式、`data/years.pl` の自動更新の意味（年境界での seed 保存）。Dockerfile の multi-stage 構造は `years-export` の削除以外そのままで、`runtime` が `test` ステージの `/tests-passed` に依存するデプロイゲートも維持しています。

## `script/smoke-test.pl`

`SMOKE_DOCKER_NETWORK` が指定されたときだけ、ホストへの publish をやめて同じ docker network に載せ、DNS ラベルとして安全な別名で引きます。ビルドステップ自身がコンテナなので、ホストの loopback へ publish しても届かないためです。**未指定時の挙動と検査内容は従来どおり**で、PR の `runtime-test` と `docs/cloud-run.md` §8 の手動手順は影響を受けません。

## PR キャッシュのトレードオフ

`test.yml` の `runtime-test` は `cache-from` から `scope=runtime` を落とします。それを書いていた master ビルドが Cloud Build へ移り、GHA キャッシュを書くジョブが無くなったためです。PR の初回ビルドは `base`（apt + Carton）から `databuild`（pod2html 約 2,500 件）までフルで回ることになりますが、

- PR に GCP の資格情報を渡さない
- PR から Artifact Registry に認証させない
- GitHub runner への data transfer out を復活させない

を優先してこの劣化を受容します。GHA 側で同じ full build をもう一度回して温めることはしません。

## 検証

**通ったもの**

- YAML 構文: `cloudbuild.yaml` / `deploy.yml` / `test.yml` / docs 内の preflight config
- shell 構文: cloudbuild 5 ステップ + preflight 5 ステップ + `deploy.yml` の全 `run:`（計 20 本）
- `perl -c script/update-years.pl` / `perl -c script/smoke-test.pl`
- `smoke-test.pl` を偽 `docker` で実行し、3 ケースを確認: 環境変数なしでは従来と同一の argv、network モードでは alias 正規化（`smoke-41087-B_vXgAHS` → `smoke-41087-b-vxgahs`）と生存確認、コンテナ即死時は即 Bail out
- キャンセル経路を workflow から取り出した実シェル処理 + `gcloud` スタブで再現検証（受理済み・ID 未保存で停止 → TAG で引き直して `CANCELLED`、他 run の TAG は非対象、終端状態には cancel を投げない、list 失敗時は保存済み ID へフォールバック）
- `substitutions._TAG` によるフィルタが gcloud で機能することを SDK のシリアライザ／フィルタ評価器で確認
- docker CLI と buildx が静的リンクであることを ELF ヘッダで確認（Alpine 由来のバイナリを glibc の perl イメージで使う前提の裏付け）
- `perl:5.42-trixie` が buildpack-deps 由来で git・gcc/g++/make・各種 dev ライブラリ・`cpm` を同梱していることを image config で確認
- `create_year_data` が DB を触らず、`commit_events` が `git log` のみであることをコード読みで確認
- years ジョブの `Resolve translation HEAD` を実際に `dash -e` で実行し、`[[: not found` / 終了コード 127 を再現。`bash -e` では `$GITHUB_OUTPUT` に `sha=...` が書かれることを確認
- `test "$GITHUB_REF" = 'refs/heads/master'` が master で通過・feature ブランチで拒否することを確認
- `create_year_data` の呼び出し元が `script/update-years.pl` だけになったことを grep で確認

**実際の Cloud Build で確認したもの（§11-2 の preflight、`asia-northeast1`）**

公式ドキュメントに明記が無く「未確認」として preflight の対象にしていた 7 項目は、**すべて実環境で通りました**（所要 65 秒）。

| # | 検証内容 | ログ上の根拠 |
|---|---|---|
| 1 | ステップから `/var/run/docker.sock` が使える | step `tools` SUCCESS |
| 2 | named volume がステップ間で共有される | 同上（`/ci` へ複製 → 後続ステップで利用） |
| 3 | `gcr.io/cloud-builders/gcloud` の PATH 上に `docker-credential-gcloud` がある | `/builder/google-cloud-sdk/bin/docker-credential-gcloud` |
| 4 | credential helper 経由で Artifact Registry に push / pull できる | step `registry` SUCCESS |
| 5 | `buildx create --driver docker-container --bootstrap` が起動する | `buildx_buildkit_preflight0` が `Status: running`、pin した digest で起動 |
| 6 | `--network cloudbuild` の隣のコンテナへ network 上の IP で HTTP 到達できる | `preflight-app ip: 192.168.10.3` → `reachability OK` |
| 7 | Alpine 由来の静的リンク docker CLI が glibc の `perl:5.42-trixie` で動き socket を使える | perl ステップから `Docker version 29.7.2, build a7dcaa6` |

**実行できていないもの**

- **`cloudbuild.yaml` 自身の 5 ステップ**。preflight が検証したのは実行環境の前提であって、production のビルド定義そのものは一度も走っていません
- **years ジョブの実行**（`cpm install` を含む）。ローカルの `local/` は別 perl 向けにビルドされており、コンテナも用意できないため未実行です
- `docker build` / 実イメージでの smoke test（Docker daemon が無く、サンドボックスが `listen()` を禁止）
- Perl の `t/`（`local/` の XS が別 perl 向けでハンドシェイク不一致。既存の環境差で本変更とは無関係）

残る未検証部分は cutover 時の確認項目が対象にしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


