### PR TITLE
years ジョブで workspace を safe.directory に登録する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,6 +134,14 @@ jobs:
           # 気づくための保険 (§7)
           test "$GITHUB_REF" = 'refs/heads/master'
 
+          # コンテナジョブは root で走る一方、workspace はランナーのユーザ所有の
+          # ままマウントされるため、git の dubious ownership 検査に引っかかる。
+          # actions/checkout は自分の実行中だけ一時的な HOME へ safe.directory を
+          # 足して後始末するので、後続の run step には残らない。
+          # 引っかかった git は「リポジトリが無い」ものとして振る舞い、git diff は
+          # --no-index の usage を、git config は not in a git directory を出す
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
           if git diff --quiet -- data/years.pl; then
             echo 'data/years.pl: no changes'
             echo "app-sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 症状

PR #78 の merge 後の Deploy（[run 34352809409](https://github.com/perldoc-jp/perldoc.jp/actions/runs/34352809409)）が、years ジョブの `Commit data/years.pl if changed` で exit 128 になり、deploy ジョブが skip されました。

```
warning: Not a git repository. Use --no-index to compare two paths outside a working tree
usage: git diff --no-index [<options>] <path> <path>
...
fatal: not in a git directory
##[error]Process completed with exit code 128.
```

`Checkout` / `Install CPAN dependencies` / `Fetch translation` / `Regenerate data/years.pl` はすべて成功しており、container ジョブ・`cpm install`・translation の取得・years.pl の再導出そのものは動いています。

## 原因

git の **dubious ownership 検査**です。

ログの `docker create` を見ると、コンテナは `--workdir /__w/perldoc.jp/perldoc.jp` の root として動く一方、workspace は `-v "/home/runner/work":"/__w"` でランナーのユーザ所有のままマウントされています。所有者が一致しないため git が検査に引っかかります。

分かりにくかったのは、git が `nongit_ok` を渡された呼び出し（`git diff` が `--no-index` をサポートするために渡す）に対しては、dubious ownership を「**リポジトリが無い**」として扱う点です。そのため所有権の問題だと分かるメッセージが出ないまま落ちていました。

`actions/checkout` は自分の実行中だけ一時的な HOME へ `safe.directory` を足して後始末する（ログの `Temporarily overriding HOME=...`）ので、後続の `run` step には残りません。`Fetch translation` が通っていたのは、そちらが root 所有の新規 clone を触っていたためです。

## 修正

push する step の冒頭で workspace を `safe.directory` に登録します。理由をコメントに残しています。

## 検証

`GIT_TEST_ASSUME_DIFFERENT_OWNER=1`（git がこの経路を試験するために持つフック）で手元に再現しました。

- 修正前の状況: `warning: Not a git repository. Use --no-index ...` と `fatal: not in a git directory` が、失敗した run と同じ形で再現
- `safe.directory` 追加後: `git diff --quiet` が差分なしで 0・差分ありで 1 を返し、`git config` も通る

YAML の読み込み、`bash -n`、`git diff --check` も通っています。

なお `actions/cache` の post step はジョブ失敗時に保存をスキップするため、次回の run は CPAN 依存をもう一度フルで入れ直します（数分〜十数分）。成功すれば以降はキャッシュに当たります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
