### PR TITLE
gcloud SDK のバージョンを固定し、submit 前に版を出す

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -246,11 +246,16 @@ jobs:
           # どの GitHub Actions run が認証したか追跡できるようにする
           request_reason: gha:${{ github.run_id }}:${{ github.run_attempt }}
 
-      # SDK のバージョンも固定する。既定の version: latest は rapid チャネルの
-      # 最新を都度取ってくるため、cloudbuild.yaml の解釈のような client 側の
-      # 挙動が run ごとに変わりうる (options.machineType の enum が無い版に当たると
-      # ".options.machineType: unused" で submit 前に落ちる)。
-      # 上げるときは、この cloudbuild.yaml がその版で解釈できることを確かめること
+      # SDK のバージョンも固定する。cloudbuild.yaml の解釈は client 側で行われ、
+      # gcloud は知らない enum 値を「そのフィールドは未使用」として扱うため、
+      # options.machineType の E2_STANDARD_2 を持たない版に当たると
+      # ".options.machineType: unused" で submit 前に落ちる。
+      # この enum 値がクライアントに入ったのは 572.0.0 で、571.0.0 以前には無い
+      # (450 / 500 / 570 で不在、572 / 573 / 574 / 578 / 582 / 584 で存在することを確認)。
+      # machine type 自体は 2023 年から使えるので、値の古さからは判断できない。
+      # 既定の version: latest だと run ごとに版が変わりうるので固定する。
+      # 上げるときは 572.0.0 以上であること、およびその版でこの cloudbuild.yaml が
+      # 解釈できることを確かめること
       - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
           version: '584.0.0'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -246,7 +246,14 @@ jobs:
           # どの GitHub Actions run が認証したか追跡できるようにする
           request_reason: gha:${{ github.run_id }}:${{ github.run_attempt }}
 
+      # SDK のバージョンも固定する。既定の version: latest は rapid チャネルの
+      # 最新を都度取ってくるため、cloudbuild.yaml の解釈のような client 側の
+      # 挙動が run ごとに変わりうる (options.machineType の enum が無い版に当たると
+      # ".options.machineType: unused" で submit 前に落ちる)。
+      # 上げるときは、この cloudbuild.yaml がその版で解釈できることを確かめること
       - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+        with:
+          version: '584.0.0'
 
       # ビルド・テスト・smoke test は Cloud Build (asia-northeast1) で行う
       # (cloudbuild.yaml)。GitHub-hosted runner が Artifact Registry から
@@ -264,6 +271,10 @@ jobs:
           # 再解釈されない
           TRANSLATION_SHA: ${{ needs.years.outputs.translation-sha }}
         run: |
+          # 失敗時にどの SDK が動いたか分かるようにする。cloudbuild.yaml の
+          # 解釈は client 側で行われるため、版が違うと結果も変わる
+          gcloud version
+
           build_id=$(gcloud builds submit "$SOURCE_REPO" \
             --project "$GCP_PROJECT_ID" \
             --region "$REGION" \

--- a/docs/cloud-run.md
+++ b/docs/cloud-run.md
@@ -1683,6 +1683,13 @@ workflow_dispatch (§9) で受けるため、翻訳がマージされてから�
   ```
   進行中のものを全部見たいときは `--filter` を外す。放置すると、次の run のビルドと
   同時に `:buildcache` を書きに行き、last-writer-wins で以後のキャッシュヒット率が落ちる
+- **gcloud SDK のバージョン**: deploy.yml は `setup-gcloud` の `version` を固定して
+  いる。`cloudbuild.yaml` の解釈は client 側 (gcloud) で行われるため、既定の
+  `latest` のままだと、`options.machineType` の enum を持たない版に当たった run だけが
+  `.options.machineType: unused` で submit 前に落ちる、といったことが起きる。
+  上げるときは、その版で `cloudbuild.yaml` が解釈できることを確かめてから上げる
+  (`gcloud builds submit --no-source --config cloudbuild.yaml` を存在しない project
+  に対して実行すると、API 呼び出しの手前まで進むので client 側の解釈だけを試せる)
 - **Docker Hub の pull 回数**: ビルド 1 回につき、ステップの image
   (`docker:<VERSION>-cli` / `moby/buildkit:<VERSION>` / `perl:5.42-trixie`) と
   Dockerfile のベース (`perl:5.42-trixie` / `perl:5.42-slim-trixie`) を Docker Hub から

--- a/docs/cloud-run.md
+++ b/docs/cloud-run.md
@@ -1684,12 +1684,16 @@ workflow_dispatch (§9) で受けるため、翻訳がマージされてから�
   進行中のものを全部見たいときは `--filter` を外す。放置すると、次の run のビルドと
   同時に `:buildcache` を書きに行き、last-writer-wins で以後のキャッシュヒット率が落ちる
 - **gcloud SDK のバージョン**: deploy.yml は `setup-gcloud` の `version` を固定して
-  いる。`cloudbuild.yaml` の解釈は client 側 (gcloud) で行われるため、既定の
-  `latest` のままだと、`options.machineType` の enum を持たない版に当たった run だけが
-  `.options.machineType: unused` で submit 前に落ちる、といったことが起きる。
-  上げるときは、その版で `cloudbuild.yaml` が解釈できることを確かめてから上げる
-  (`gcloud builds submit --no-source --config cloudbuild.yaml` を存在しない project
-  に対して実行すると、API 呼び出しの手前まで進むので client 側の解釈だけを試せる)
+  いる。`cloudbuild.yaml` の解釈は client 側 (gcloud) で行われ、gcloud は知らない
+  enum 値を「そのフィールドは未使用」として扱う。`options.machineType` の
+  `E2_STANDARD_2` がクライアントの enum に入ったのは **572.0.0** で、571.0.0 以前には
+  無い (450 / 500 / 570 で不在、572 以降で存在することを確認)。machine type 自体は
+  2023 年から使えるため、値の古さからは判断できない。それ以前の版で submit すると
+  `.options.machineType: unused` で submit の手前で落ちる。
+  上げるときは 572.0.0 以上であること、およびその版でこの `cloudbuild.yaml` が
+  解釈できることを確かめてから上げる (存在しない project に対して
+  `gcloud builds submit --no-source --config cloudbuild.yaml` を実行すると、
+  API 呼び出しの手前まで進むので client 側の解釈だけを試せる)
 - **Docker Hub の pull 回数**: ビルド 1 回につき、ステップの image
   (`docker:<VERSION>-cli` / `moby/buildkit:<VERSION>` / `perl:5.42-trixie`) と
   Dockerfile のベース (`perl:5.42-trixie` / `perl:5.42-slim-trixie`) を Docker Hub から


### PR DESCRIPTION
## 症状

PR #79 merge 後の Deploy（[run 34361452920](https://github.com/perldoc-jp/perldoc.jp/actions/runs/34361452920)）が、`Submit build to Cloud Build` で submit 前に落ちました。years ジョブは通っています（safe.directory の修正は効いています）。

```
ERROR: (gcloud.builds.submit) interpreting cloudbuild.yaml as build config: .options.machineType: unused
```

## メカニズム

このメッセージは gcloud が apitools の `all_unrecognized_fields()` を見て出すもので、**未知の enum 値**でも「そのフィールドは未使用」として同じ形で出ます。手元で確認しました。

| 入力 | 結果 |
|---|---|
| `machineType: E2_STANDARD_2` | parsed OK |
| `machineType: BOGUS_VALUE_XYZ` | `.options.machineType: unused` |
| `notAField: 1` | `.options.notAField: unused` |
| `machineType: e2-standard-2`（小文字） | `.options.machineType: unused` |

`logging: CLOUD_LOGGING_ONLY` は解釈されて `machineType` だけが落ちている非対称も、これで説明が付きます。

## `E2_STANDARD_2` は gcloud クライアントでは新しい値です

「e2-standard-2 は 2023 年から使えるのだから、未知の値というのは不自然」という疑問が当然出ます。実際に配布物を取って調べたところ、**machine type の提供時期と、enum 値がクライアントに入った時期は大きくずれていました。**

| gcloud | `E2_STANDARD_2` |
|---|---|
| 450.0.0 / 500.0.0 / 570.0.0 / 571.0.0 | **なし**（enum は `E2_MEDIUM = 5` で終わり） |
| 572.0.0 / 573.0.0 / 574.0.0 / 578.0.0 / 582.0.0 / 584.0.0 | あり |

つまり **572.0.0 で追加**されており、571.0.0 以前で submit すると必ずこのエラーになります。値の古さからは判断できません。

## 再現できていない点

**同じ失敗を手元で再現できていません。**

- 実行時に読まれた `cloudbuild.yaml`（`1d74900d`）は手元と**バイト同一**。BOM・CR・タブ無し、`machineType: E2_STANDARD_2` は 2 スペースインデントの純 ASCII
- ランナーイメージ `20260831.293.1` の同梱 gcloud は 582.0.0、`setup-gcloud` の `latest` は 584.0.0。**どちらも 572.0.0 以上**
- 584 の実 CLI で、ワークフローと同じ形（git source + 相対パスの `--config` + `--service-account` + `--substitutions`）を存在しない project に対して実行すると、config の解釈を通過して API 呼び出しまで到達する
- 582 / 584 の config ローダ（`config.py` / `cloudbuild_util.py` / `submit_util.py`）は差分なし

**どの gcloud が動いたのかがログから分からない**ことが、残っている本質的な問題です。

## 修正

1. **`setup-gcloud` の `version` を `584.0.0` に固定**します。既定の `latest` は rapid チャネルの最新を都度取ってくるため、client 側で行われる `cloudbuild.yaml` の解釈が run ごとに変わりえます。
2. **submit の直前に `gcloud version` を出力**します。次に同じことが起きたら、どの SDK が動いたかがログだけで分かります。

`docs/cloud-run.md` の「運用」に、閾値（572.0.0 以上が必要）と、pin を上げるときの確認手順（存在しない project への `--no-source` 実行で client 側の解釈だけ試す）を書きました。

## 限界

固定する 584.0.0 でこの config が解釈できることは確認済みですが、**ランナー上で実際に何が動いたかは未解明**です。もし 584 が動いていたのなら、この pin では直りません。その場合は `gcloud version` の出力から版が特定できるので、そこで確実に詰められます。

さらに堅くするなら、`options.machineType` を落として `--machine-type=e2-standard-2` を CLI で渡す手もあります。enum を持たない版では argparse が `invalid choice: 'e2-standard-2' (choose from ...)` と**対応値を列挙して**落ちるため、失敗が自己診断的になります（584 で動作確認済み）。ただし設定が config から離れるため、この PR では採っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
